### PR TITLE
Added pagination properties to plural types

### DIFF
--- a/src/generators/types.ts
+++ b/src/generators/types.ts
@@ -130,6 +130,39 @@ export const generateTypes = (
 
     /**
      * ```ts
+     * Array<SchemaSlug>;
+     * ```
+     */
+    const pluralModelArrayTypeDec = factory.createTypeReferenceNode(
+      identifiers.primitive.array,
+      [modelSchemaName],
+    );
+
+    /**
+     * ```ts
+     * {
+     *  moreBefore?: string;
+     *  moreAfter?: string;
+     * };
+     * ```
+     */
+    const pluralModelPaginationPropsTypeDec = factory.createTypeLiteralNode([
+      factory.createPropertySignature(
+        undefined,
+        factory.createIdentifier('moreBefore'),
+        factory.createToken(SyntaxKind.QuestionToken),
+        factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+      ),
+      factory.createPropertySignature(
+        undefined,
+        factory.createIdentifier('moreAfter'),
+        factory.createToken(SyntaxKind.QuestionToken),
+        factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+      ),
+    ]);
+
+    /**
+     * ```ts
      * export type SchemaPluralSlug = Array<SchemaSlug>;
      * ```
      */
@@ -137,7 +170,10 @@ export const generateTypes = (
       [factory.createModifier(SyntaxKind.ExportKeyword)],
       pluralSchemaIdentifier,
       undefined,
-      factory.createTypeReferenceNode(identifiers.primitive.array, [modelSchemaName]),
+      factory.createIntersectionTypeNode([
+        pluralModelArrayTypeDec,
+        pluralModelPaginationPropsTypeDec,
+      ]),
     );
 
     // If the model does not have a summary / description

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -8,7 +8,10 @@ interface AccountSchema extends ResultRecord {
     name: string;
 }
 export type Account = AccountSchema;
-export type Accounts = Array<AccountSchema>;
+export type Accounts = Array<AccountSchema> & {
+    moreBefore?: string;
+    moreAfter?: string;
+};
 declare module "ronin" {
     declare const add: {
         /* Add a single account record */

--- a/tests/generators/__snapshots__/types.test.ts.snap
+++ b/tests/generators/__snapshots__/types.test.ts.snap
@@ -6,7 +6,10 @@ exports[`types a basic model 1`] = `
     name: string;
 }
 export type Account = AccountSchema;
-export type Accounts = Array<AccountSchema>;
+export type Accounts = Array<AccountSchema> & {
+    moreBefore?: string;
+    moreAfter?: string;
+};
 "
 `;
 
@@ -25,7 +28,10 @@ export type Account = AccountSchema;
 /**
  * A user account.
  */
-export type Accounts = Array<AccountSchema>;
+export type Accounts = Array<AccountSchema> & {
+    moreBefore?: string;
+    moreAfter?: string;
+};
 "
 `;
 
@@ -35,13 +41,19 @@ exports[`types a model with a link field 1`] = `
     name: string;
 }
 export type Account = AccountSchema;
-export type Accounts = Array<AccountSchema>;
+export type Accounts = Array<AccountSchema> & {
+    moreBefore?: string;
+    moreAfter?: string;
+};
 interface PostSchema extends ResultRecord {
     author: AccountSchema | unknown;
     title: string;
 }
 export type Post = PostSchema;
-export type  = Array<PostSchema>;
+export type  = Array<PostSchema> & {
+    moreBefore?: string;
+    moreAfter?: string;
+};
 "
 `;
 
@@ -52,6 +64,9 @@ exports[`types a model with a link field that does not exist 1`] = `
     name: string;
 }
 export type Account = AccountSchema;
-export type Accounts = Array<AccountSchema>;
+export type Accounts = Array<AccountSchema> & {
+    moreBefore?: string;
+    moreAfter?: string;
+};
 "
 `;


### PR DESCRIPTION
This change updates the code generation for schema types such that any plural type (For example: `Users`, `Posts`, etc) will have an intersection added to include optional properties for both `moreBefore` & `moreAfter`.