### PR TITLE
Add schema types to exports

### DIFF
--- a/src/generators/module.ts
+++ b/src/generators/module.ts
@@ -21,6 +21,41 @@ import type { Model } from '@/src/types/model';
 export const generateModule = (models: Array<Model>): ModuleDeclaration => {
   const moduleBodyStatements = new Array<Statement>();
 
+  /**
+   * ```ts
+   * export type { Account, Accounts };
+   * ```
+   */
+  const exportTypeDeclaration = factory.createExportDeclaration(
+    undefined,
+    true,
+    factory.createNamedExports(
+      models.flatMap((model) => {
+        const singularModelIdentifier = factory.createIdentifier(
+          convertToPascalCase(model.slug),
+        );
+        const pluralSchemaIdentifier = factory.createIdentifier(
+          convertToPascalCase(model.pluralSlug),
+        );
+
+        return [
+          factory.createExportSpecifier(false, undefined, singularModelIdentifier),
+          factory.createExportSpecifier(false, undefined, pluralSchemaIdentifier),
+        ];
+      }),
+    ),
+  );
+  moduleBodyStatements.push(exportTypeDeclaration);
+
+  /**
+   * ```ts
+   * declare const add: {};
+   * declare const count: {};
+   * declare const get: {};
+   * declare const remove: {};
+   * declare const set: {};
+   * ```
+   */
   for (const queryType of QUERY_TYPE_NAMES) {
     const declarationProperties = new Array<TypeElement>();
     for (const model of models) {

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -13,6 +13,7 @@ export type Accounts = Array<AccountSchema> & {
     moreAfter?: string;
 };
 declare module "ronin" {
+    export type { Account, Accounts };
     declare const add: {
         /* Add a single account record */
         account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
@@ -49,6 +50,7 @@ exports[`generate with no models 1`] = `
 "import type { AddQuery, CountQuery, GetQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
 import type { DeepCallable, ResultRecord } from "@ronin/syntax/queries";
 declare module "ronin" {
+    export type {};
     declare const add: {};
     declare const count: {};
     declare const get: {};

--- a/tests/generators/__snapshots__/module.test.ts.snap
+++ b/tests/generators/__snapshots__/module.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`module a basic model 1`] = `
 "declare module "ronin" {
+    export type { Account, Accounts };
     declare const add: {
         /* Add a single account record */
         account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
@@ -36,6 +37,7 @@ exports[`module a basic model 1`] = `
 
 exports[`module with no modules 1`] = `
 "declare module "ronin" {
+    export type {};
     declare const add: {};
     declare const count: {};
     declare const get: {};
@@ -47,6 +49,7 @@ exports[`module with no modules 1`] = `
 
 exports[`module with multiple models 1`] = `
 "declare module "ronin" {
+    export type { Account, Accounts, Post, Posts };
     declare const add: {
         /* Add a single account record */
         account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;


### PR DESCRIPTION
This change updates the code generations module augmentation code to also include an `export type { ... }` block so all the schema types generated outside the module augmentation can be accessed by users.