### PR TITLE
Improved comment generator details

### DIFF
--- a/src/generators/comment.ts
+++ b/src/generators/comment.ts
@@ -1,6 +1,7 @@
 import { READABLE_QUERY_TYPE_NAMES } from '@/src/constants/schema';
 
 import type { QUERY_TYPE_NAMES } from '@/src/constants/schema';
+import type { Model } from '@/src/types/model';
 
 interface GenerateQueryTypeCommentResult {
   singular: string;
@@ -16,9 +17,9 @@ interface GenerateQueryTypeCommentResult {
  * @returns An object containing both the singular and plural comment strings.
  */
 export const generateQueryTypeComment = (
-  modelName: string,
+  model: Model,
   queryType: (typeof QUERY_TYPE_NAMES)[number],
 ): GenerateQueryTypeCommentResult => ({
-  singular: ` ${READABLE_QUERY_TYPE_NAMES[queryType]} a single ${modelName} record `,
-  plural: ` ${READABLE_QUERY_TYPE_NAMES[queryType]} multiple ${modelName} records `,
+  singular: ` ${READABLE_QUERY_TYPE_NAMES[queryType]} a single ${model.name ?? model.slug} record `,
+  plural: ` ${READABLE_QUERY_TYPE_NAMES[queryType]} multiple ${model.name ?? model.slug} records `,
 });

--- a/src/generators/module.ts
+++ b/src/generators/module.ts
@@ -59,7 +59,7 @@ export const generateModule = (models: Array<Model>): ModuleDeclaration => {
   for (const queryType of QUERY_TYPE_NAMES) {
     const declarationProperties = new Array<TypeElement>();
     for (const model of models) {
-      const comment = generateQueryTypeComment(model.slug, queryType);
+      const comment = generateQueryTypeComment(model, queryType);
       const singularModelIdentifier = factory.createTypeReferenceNode(
         convertToPascalCase(model.slug),
       );

--- a/tests/generators/__snapshots__/comment.test.ts.snap
+++ b/tests/generators/__snapshots__/comment.test.ts.snap
@@ -1,34 +1,69 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`comment add 1`] = `
+exports[`comment add with model name 1`] = `
+{
+  "plural": " Add multiple Account records ",
+  "singular": " Add a single Account record ",
+}
+`;
+
+exports[`comment add with model slug 1`] = `
 {
   "plural": " Add multiple account records ",
   "singular": " Add a single account record ",
 }
 `;
 
-exports[`comment count 1`] = `
+exports[`comment count with model name 1`] = `
+{
+  "plural": " Count multiple Account records ",
+  "singular": " Count a single Account record ",
+}
+`;
+
+exports[`comment count with model slug 1`] = `
 {
   "plural": " Count multiple account records ",
   "singular": " Count a single account record ",
 }
 `;
 
-exports[`comment get 1`] = `
+exports[`comment get with model name 1`] = `
+{
+  "plural": " Get multiple Account records ",
+  "singular": " Get a single Account record ",
+}
+`;
+
+exports[`comment get with model slug 1`] = `
 {
   "plural": " Get multiple account records ",
   "singular": " Get a single account record ",
 }
 `;
 
-exports[`comment remove 1`] = `
+exports[`comment remove with model name 1`] = `
+{
+  "plural": " Remove multiple Account records ",
+  "singular": " Remove a single Account record ",
+}
+`;
+
+exports[`comment remove with model slug 1`] = `
 {
   "plural": " Remove multiple account records ",
   "singular": " Remove a single account record ",
 }
 `;
 
-exports[`comment set 1`] = `
+exports[`comment set with model name 1`] = `
+{
+  "plural": " Set multiple Account records ",
+  "singular": " Set a single Account record ",
+}
+`;
+
+exports[`comment set with model slug 1`] = `
 {
   "plural": " Set multiple account records ",
   "singular": " Set a single account record ",

--- a/tests/generators/comment.test.ts
+++ b/tests/generators/comment.test.ts
@@ -2,31 +2,71 @@ import { describe, expect, test } from 'bun:test';
 
 import { generateQueryTypeComment } from '@/src/generators/comment';
 
+import type { Model } from '@/src/types/model';
+
 describe('comment', () => {
-  const modelName = 'account';
-
-  test('add', () => {
-    const comment = generateQueryTypeComment(modelName, 'add');
-    expect(comment).toMatchSnapshot();
+  describe('add', () => {
+    test('with model name', () => {
+      const model = { name: 'Account', slug: 'account' } as Model;
+      const comment = generateQueryTypeComment(model, 'add');
+      expect(comment).toMatchSnapshot();
+    });
+    test('with model slug', () => {
+      const model = { slug: 'account' } as Model;
+      const comment = generateQueryTypeComment(model, 'add');
+      expect(comment).toMatchSnapshot();
+    });
   });
 
-  test('count', () => {
-    const comment = generateQueryTypeComment(modelName, 'count');
-    expect(comment).toMatchSnapshot();
+  describe('count', () => {
+    test('with model name', () => {
+      const model = { name: 'Account', slug: 'account' } as Model;
+      const comment = generateQueryTypeComment(model, 'count');
+      expect(comment).toMatchSnapshot();
+    });
+    test('with model slug', () => {
+      const model = { slug: 'account' } as Model;
+      const comment = generateQueryTypeComment(model, 'count');
+      expect(comment).toMatchSnapshot();
+    });
   });
 
-  test('get', () => {
-    const comment = generateQueryTypeComment(modelName, 'get');
-    expect(comment).toMatchSnapshot();
+  describe('get', () => {
+    test('with model name', () => {
+      const model = { name: 'Account', slug: 'account' } as Model;
+      const comment = generateQueryTypeComment(model, 'get');
+      expect(comment).toMatchSnapshot();
+    });
+    test('with model slug', () => {
+      const model = { slug: 'account' } as Model;
+      const comment = generateQueryTypeComment(model, 'get');
+      expect(comment).toMatchSnapshot();
+    });
   });
 
-  test('remove', () => {
-    const comment = generateQueryTypeComment(modelName, 'remove');
-    expect(comment).toMatchSnapshot();
+  describe('remove', () => {
+    test('with model name', () => {
+      const model = { name: 'Account', slug: 'account' } as Model;
+      const comment = generateQueryTypeComment(model, 'remove');
+      expect(comment).toMatchSnapshot();
+    });
+    test('with model slug', () => {
+      const model = { slug: 'account' } as Model;
+      const comment = generateQueryTypeComment(model, 'remove');
+      expect(comment).toMatchSnapshot();
+    });
   });
 
-  test('set', () => {
-    const comment = generateQueryTypeComment(modelName, 'set');
-    expect(comment).toMatchSnapshot();
+  describe('set', () => {
+    test('with model name', () => {
+      const model = { name: 'Account', slug: 'account' } as Model;
+      const comment = generateQueryTypeComment(model, 'set');
+      expect(comment).toMatchSnapshot();
+    });
+    test('with model slug', () => {
+      const model = { slug: 'account' } as Model;
+      const comment = generateQueryTypeComment(model, 'set');
+      expect(comment).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
This change updates the comment generator to use the `model.name` by default & optionally fallback to the `model.slug` like before.