### PR TITLE
Fix exported schema types scope

### DIFF
--- a/src/generators/module.ts
+++ b/src/generators/module.ts
@@ -5,7 +5,13 @@ import { QUERY_TYPE_NAMES } from '@/src/constants/schema';
 import { generateQueryTypeComment } from '@/src/generators/comment';
 import { convertToPascalCase } from '@/src/utils/slug';
 
-import type { ModuleDeclaration, Statement, TypeElement } from 'typescript';
+import type {
+  InterfaceDeclaration,
+  ModuleDeclaration,
+  Statement,
+  TypeAliasDeclaration,
+  TypeElement,
+} from 'typescript';
 
 import type { Model } from '@/src/types/model';
 
@@ -15,37 +21,19 @@ import type { Model } from '@/src/types/model';
  * this space.
  *
  * @param models - An array of RONIN models to generate type definitions for.
+ * @param schemas - An array of type declarations for the models.
  *
  * @returns A module augmentation declaration to be added to `index.d.ts`.
  */
-export const generateModule = (models: Array<Model>): ModuleDeclaration => {
+export const generateModule = (
+  models: Array<Model>,
+  schemas: Array<InterfaceDeclaration | TypeAliasDeclaration>,
+): ModuleDeclaration => {
   const moduleBodyStatements = new Array<Statement>();
 
-  /**
-   * ```ts
-   * export type { Account, Accounts };
-   * ```
-   */
-  const exportTypeDeclaration = factory.createExportDeclaration(
-    undefined,
-    true,
-    factory.createNamedExports(
-      models.flatMap((model) => {
-        const singularModelIdentifier = factory.createIdentifier(
-          convertToPascalCase(model.slug),
-        );
-        const pluralSchemaIdentifier = factory.createIdentifier(
-          convertToPascalCase(model.pluralSlug),
-        );
-
-        return [
-          factory.createExportSpecifier(false, undefined, singularModelIdentifier),
-          factory.createExportSpecifier(false, undefined, pluralSchemaIdentifier),
-        ];
-      }),
-    ),
-  );
-  moduleBodyStatements.push(exportTypeDeclaration);
+  for (const schemaTypeDec of schemas) {
+    moduleBodyStatements.push(schemaTypeDec);
+  }
 
   /**
    * ```ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,9 @@ export const generate = (models: Array<Model>): string => {
 
   // Generate and add the type declarations for each model.
   const typeDeclarations = generateTypes(models);
-  for (const typeDeclaration of typeDeclarations) nodes.push(typeDeclaration);
 
   // Generate and add the `ronin` module augmentation..
-  const moduleAugmentation = generateModule(models);
+  const moduleAugmentation = generateModule(models, typeDeclarations);
   nodes.push(moduleAugmentation);
 
   return printNodes(nodes);

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -3,17 +3,16 @@
 exports[`generate a basic model 1`] = `
 "import type { AddQuery, CountQuery, GetQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
 import type { DeepCallable, ResultRecord } from "@ronin/syntax/queries";
-interface AccountSchema extends ResultRecord {
-    email: string;
-    name: string;
-}
-export type Account = AccountSchema;
-export type Accounts = Array<AccountSchema> & {
-    moreBefore?: string;
-    moreAfter?: string;
-};
 declare module "ronin" {
-    export type { Account, Accounts };
+    interface AccountSchema extends ResultRecord {
+        email: string;
+        name: string;
+    }
+    export type Account = AccountSchema;
+    export type Accounts = Array<AccountSchema> & {
+        moreBefore?: string;
+        moreAfter?: string;
+    };
     declare const add: {
         /* Add a single account record */
         account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
@@ -50,7 +49,6 @@ exports[`generate with no models 1`] = `
 "import type { AddQuery, CountQuery, GetQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
 import type { DeepCallable, ResultRecord } from "@ronin/syntax/queries";
 declare module "ronin" {
-    export type {};
     declare const add: {};
     declare const count: {};
     declare const get: {};

--- a/tests/generators/__snapshots__/module.test.ts.snap
+++ b/tests/generators/__snapshots__/module.test.ts.snap
@@ -1,8 +1,18 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`module with no modules 1`] = `
+"declare module "ronin" {
+    declare const add: {};
+    declare const count: {};
+    declare const get: {};
+    declare const remove: {};
+    declare const set: {};
+}
+"
+`;
+
 exports[`module a basic model 1`] = `
 "declare module "ronin" {
-    export type { Account, Accounts };
     declare const add: {
         /* Add a single account record */
         account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
@@ -35,21 +45,8 @@ exports[`module a basic model 1`] = `
 "
 `;
 
-exports[`module with no modules 1`] = `
-"declare module "ronin" {
-    export type {};
-    declare const add: {};
-    declare const count: {};
-    declare const get: {};
-    declare const remove: {};
-    declare const set: {};
-}
-"
-`;
-
 exports[`module with multiple models 1`] = `
 "declare module "ronin" {
-    export type { Account, Accounts, Post, Posts };
     declare const add: {
         /* Add a single account record */
         account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;

--- a/tests/generators/__snapshots__/module.test.ts.snap
+++ b/tests/generators/__snapshots__/module.test.ts.snap
@@ -1,18 +1,16 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`module with no modules 1`] = `
-"declare module "ronin" {
-    declare const add: {};
-    declare const count: {};
-    declare const get: {};
-    declare const remove: {};
-    declare const set: {};
-}
-"
-`;
-
 exports[`module a basic model 1`] = `
 "declare module "ronin" {
+    interface AccountSchema extends ResultRecord {
+        email: string;
+        name: string;
+    }
+    export type Account = AccountSchema;
+    export type Accounts = Array<AccountSchema> & {
+        moreBefore?: string;
+        moreAfter?: string;
+    };
     declare const add: {
         /* Add a single account record */
         account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
@@ -45,8 +43,37 @@ exports[`module a basic model 1`] = `
 "
 `;
 
+exports[`module with no modules 1`] = `
+"declare module "ronin" {
+    declare const add: {};
+    declare const count: {};
+    declare const get: {};
+    declare const remove: {};
+    declare const set: {};
+}
+"
+`;
+
 exports[`module with multiple models 1`] = `
 "declare module "ronin" {
+    interface AccountSchema extends ResultRecord {
+        email: string;
+        name: string;
+    }
+    export type Account = AccountSchema;
+    export type Accounts = Array<AccountSchema> & {
+        moreBefore?: string;
+        moreAfter?: string;
+    };
+    interface PostSchema extends ResultRecord {
+        description: string;
+        title: string;
+    }
+    export type Post = PostSchema;
+    export type Posts = Array<PostSchema> & {
+        moreBefore?: string;
+        moreAfter?: string;
+    };
     declare const add: {
         /* Add a single account record */
         account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;

--- a/tests/generators/module.test.ts
+++ b/tests/generators/module.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { model, string } from 'ronin/schema';
 
 import { generateModule } from '@/src/generators/module';
+import { generateTypes } from '@/src/generators/types';
 import { printNodes } from '@/src/utils/print';
 
 describe('module', () => {
@@ -15,11 +16,18 @@ describe('module', () => {
       },
     });
 
-    const moduleDeclaration = generateModule(
-      // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.
+    const models = [AccountModel];
+
+    // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.
+    const schemas = generateTypes(
       // @ts-expect-error Codegen models types differ from the schema model types.
-      [AccountModel],
-      [],
+      models,
+    );
+
+    const moduleDeclaration = generateModule(
+      // @ts-expect-error Codegen models types differ from the schema model types.
+      models,
+      schemas,
     );
 
     const moduleDeclarationStr = printNodes([moduleDeclaration]);
@@ -54,10 +62,18 @@ describe('module', () => {
       },
     });
 
+    const models = [AccountModel, PostModel];
+
+    // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.
+    const schemas = generateTypes(
+      // @ts-expect-error Codegen models types differ from the schema model types.
+      models,
+    );
+
     const moduleDeclaration = generateModule(
       // @ts-expect-error Codegen models types differ from the schema model types.
-      [AccountModel, PostModel],
-      [],
+      models,
+      schemas,
     );
     const moduleDeclarationStr = printNodes([moduleDeclaration]);
     expect(moduleDeclarationStr).toMatchSnapshot();

--- a/tests/generators/module.test.ts
+++ b/tests/generators/module.test.ts
@@ -15,9 +15,12 @@ describe('module', () => {
       },
     });
 
-    // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.
-    // @ts-expect-error Codegen models types differ from the schema model types.
-    const moduleDeclaration = generateModule([AccountModel]);
+    const moduleDeclaration = generateModule(
+      // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.
+      // @ts-expect-error Codegen models types differ from the schema model types.
+      [AccountModel],
+      [],
+    );
 
     const moduleDeclarationStr = printNodes([moduleDeclaration]);
 
@@ -25,7 +28,7 @@ describe('module', () => {
   });
 
   test('with no modules', () => {
-    const moduleDeclaration = generateModule([]);
+    const moduleDeclaration = generateModule([], []);
 
     const moduleDeclarationStr = printNodes([moduleDeclaration]);
 
@@ -51,8 +54,11 @@ describe('module', () => {
       },
     });
 
-    // @ts-expect-error Codegen models types differ from the schema model types.
-    const moduleDeclaration = generateModule([AccountModel, PostModel]);
+    const moduleDeclaration = generateModule(
+      // @ts-expect-error Codegen models types differ from the schema model types.
+      [AccountModel, PostModel],
+      [],
+    );
     const moduleDeclarationStr = printNodes([moduleDeclaration]);
     expect(moduleDeclarationStr).toMatchSnapshot();
   });


### PR DESCRIPTION
This change fixes an in issue introduced in #5 where the the type inference for queries would break if you imported any of the exported schema types. To fix this, all schema types are now created and exported from directly inside the module declaration.