### PR TITLE
Simplified automatic factory types

### DIFF
--- a/src/generators/module.ts
+++ b/src/generators/module.ts
@@ -152,6 +152,12 @@ export const generateModule = (
   }
 
   // Note: `csf` prefix stands for `createSyntaxFactory`.
+
+  /**
+   * ```ts
+   * (options: QueryHandlerOptions | (() => QueryHandlerOptions))
+   * ```
+   */
   const csfParameterTypeDec = factory.createParameterDeclaration(
     undefined,
     undefined,
@@ -166,6 +172,18 @@ export const generateModule = (
       ),
     ]),
   );
+
+  /**
+   * ```ts
+   * (...) => {
+   *  add: { ... },
+   *  count: { ... },
+   *  get: { ... },
+   *  remove: { ... },
+   *  set: { ... },
+   * }
+   * ```
+   */
   const csfReturnTypeDec = factory.createTypeLiteralNode(
     mappedQueryTypeVariableDeclarations.map(({ properties, queryType }) => {
       return factory.createPropertySignature(

--- a/src/generators/module.ts
+++ b/src/generators/module.ts
@@ -176,23 +176,23 @@ export const generateModule = (
   /**
    * ```ts
    * (...) => {
-   *  add: { ... },
-   *  count: { ... },
-   *  get: { ... },
-   *  remove: { ... },
-   *  set: { ... },
+   *  add: typeof add,
+   *  count: typeof count,
+   *  get: typeof get,
+   *  remove: typeof remove,
+   *  set: typeof set,
    * }
    * ```
    */
   const csfReturnTypeDec = factory.createTypeLiteralNode(
-    mappedQueryTypeVariableDeclarations.map(({ properties, queryType }) => {
-      return factory.createPropertySignature(
+    QUERY_TYPE_NAMES.map((queryType) =>
+      factory.createPropertySignature(
         undefined,
-        queryType,
+        factory.createIdentifier(queryType),
         undefined,
-        factory.createTypeLiteralNode(properties),
-      );
-    }),
+        factory.createTypeQueryNode(factory.createIdentifier(queryType)),
+      ),
+    ),
   );
 
   moduleBodyStatements.push(

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -43,64 +43,18 @@ declare module "ronin" {
         accounts: DeepCallable<SetQuery[keyof SetQuery], Accounts>;
     };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
-        add: {
-            /* Add a single account record */
-            account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
-        };
-        count: {
-            /* Count a single account record */
-            account: DeepCallable<CountQuery[keyof CountQuery], Account | null>;
-            /* Count multiple account records */
-            accounts: DeepCallable<CountQuery[keyof CountQuery], Accounts>;
-        };
-        get: {
-            /* Get a single account record */
-            account: DeepCallable<GetQuery[keyof GetQuery], Account | null>;
-            /* Get multiple account records */
-            accounts: DeepCallable<GetQuery[keyof GetQuery], Accounts>;
-        };
-        remove: {
-            /* Remove a single account record */
-            account: DeepCallable<RemoveQuery[keyof RemoveQuery], Account | null>;
-            /* Remove multiple account records */
-            accounts: DeepCallable<RemoveQuery[keyof RemoveQuery], Accounts>;
-        };
-        set: {
-            /* Set a single account record */
-            account: DeepCallable<SetQuery[keyof SetQuery], Account | null>;
-            /* Set multiple account records */
-            accounts: DeepCallable<SetQuery[keyof SetQuery], Accounts>;
-        };
+        add: typeof add;
+        count: typeof count;
+        get: typeof get;
+        remove: typeof remove;
+        set: typeof set;
     };
     export default function (options: QueryHandlerOptions | (() => QueryHandlerOptions)): {
-        add: {
-            /* Add a single account record */
-            account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
-        };
-        count: {
-            /* Count a single account record */
-            account: DeepCallable<CountQuery[keyof CountQuery], Account | null>;
-            /* Count multiple account records */
-            accounts: DeepCallable<CountQuery[keyof CountQuery], Accounts>;
-        };
-        get: {
-            /* Get a single account record */
-            account: DeepCallable<GetQuery[keyof GetQuery], Account | null>;
-            /* Get multiple account records */
-            accounts: DeepCallable<GetQuery[keyof GetQuery], Accounts>;
-        };
-        remove: {
-            /* Remove a single account record */
-            account: DeepCallable<RemoveQuery[keyof RemoveQuery], Account | null>;
-            /* Remove multiple account records */
-            accounts: DeepCallable<RemoveQuery[keyof RemoveQuery], Accounts>;
-        };
-        set: {
-            /* Set a single account record */
-            account: DeepCallable<SetQuery[keyof SetQuery], Account | null>;
-            /* Set multiple account records */
-            accounts: DeepCallable<SetQuery[keyof SetQuery], Accounts>;
-        };
+        add: typeof add;
+        count: typeof count;
+        get: typeof get;
+        remove: typeof remove;
+        set: typeof set;
     };
 }
 "
@@ -117,18 +71,18 @@ declare module "ronin" {
     declare const remove: {};
     declare const set: {};
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
-        add: {};
-        count: {};
-        get: {};
-        remove: {};
-        set: {};
+        add: typeof add;
+        count: typeof count;
+        get: typeof get;
+        remove: typeof remove;
+        set: typeof set;
     };
     export default function (options: QueryHandlerOptions | (() => QueryHandlerOptions)): {
-        add: {};
-        count: {};
-        get: {};
-        remove: {};
-        set: {};
+        add: typeof add;
+        count: typeof count;
+        get: typeof get;
+        remove: typeof remove;
+        set: typeof set;
     };
 }
 "

--- a/tests/generators/__snapshots__/module.test.ts.snap
+++ b/tests/generators/__snapshots__/module.test.ts.snap
@@ -40,64 +40,18 @@ exports[`module a basic model 1`] = `
         accounts: DeepCallable<SetQuery[keyof SetQuery], Accounts>;
     };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
-        add: {
-            /* Add a single account record */
-            account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
-        };
-        count: {
-            /* Count a single account record */
-            account: DeepCallable<CountQuery[keyof CountQuery], Account | null>;
-            /* Count multiple account records */
-            accounts: DeepCallable<CountQuery[keyof CountQuery], Accounts>;
-        };
-        get: {
-            /* Get a single account record */
-            account: DeepCallable<GetQuery[keyof GetQuery], Account | null>;
-            /* Get multiple account records */
-            accounts: DeepCallable<GetQuery[keyof GetQuery], Accounts>;
-        };
-        remove: {
-            /* Remove a single account record */
-            account: DeepCallable<RemoveQuery[keyof RemoveQuery], Account | null>;
-            /* Remove multiple account records */
-            accounts: DeepCallable<RemoveQuery[keyof RemoveQuery], Accounts>;
-        };
-        set: {
-            /* Set a single account record */
-            account: DeepCallable<SetQuery[keyof SetQuery], Account | null>;
-            /* Set multiple account records */
-            accounts: DeepCallable<SetQuery[keyof SetQuery], Accounts>;
-        };
+        add: typeof add;
+        count: typeof count;
+        get: typeof get;
+        remove: typeof remove;
+        set: typeof set;
     };
     export default function (options: QueryHandlerOptions | (() => QueryHandlerOptions)): {
-        add: {
-            /* Add a single account record */
-            account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
-        };
-        count: {
-            /* Count a single account record */
-            account: DeepCallable<CountQuery[keyof CountQuery], Account | null>;
-            /* Count multiple account records */
-            accounts: DeepCallable<CountQuery[keyof CountQuery], Accounts>;
-        };
-        get: {
-            /* Get a single account record */
-            account: DeepCallable<GetQuery[keyof GetQuery], Account | null>;
-            /* Get multiple account records */
-            accounts: DeepCallable<GetQuery[keyof GetQuery], Accounts>;
-        };
-        remove: {
-            /* Remove a single account record */
-            account: DeepCallable<RemoveQuery[keyof RemoveQuery], Account | null>;
-            /* Remove multiple account records */
-            accounts: DeepCallable<RemoveQuery[keyof RemoveQuery], Accounts>;
-        };
-        set: {
-            /* Set a single account record */
-            account: DeepCallable<SetQuery[keyof SetQuery], Account | null>;
-            /* Set multiple account records */
-            accounts: DeepCallable<SetQuery[keyof SetQuery], Accounts>;
-        };
+        add: typeof add;
+        count: typeof count;
+        get: typeof get;
+        remove: typeof remove;
+        set: typeof set;
     };
 }
 "
@@ -111,18 +65,18 @@ exports[`module with no modules 1`] = `
     declare const remove: {};
     declare const set: {};
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
-        add: {};
-        count: {};
-        get: {};
-        remove: {};
-        set: {};
+        add: typeof add;
+        count: typeof count;
+        get: typeof get;
+        remove: typeof remove;
+        set: typeof set;
     };
     export default function (options: QueryHandlerOptions | (() => QueryHandlerOptions)): {
-        add: {};
-        count: {};
-        get: {};
-        remove: {};
-        set: {};
+        add: typeof add;
+        count: typeof count;
+        get: typeof get;
+        remove: typeof remove;
+        set: typeof set;
     };
 }
 "
@@ -195,100 +149,18 @@ exports[`module with multiple models 1`] = `
         posts: DeepCallable<SetQuery[keyof SetQuery], Posts>;
     };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
-        add: {
-            /* Add a single account record */
-            account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
-            /* Add a single post record */
-            post: DeepCallable<AddQuery[keyof AddQuery], Post | null>;
-        };
-        count: {
-            /* Count a single account record */
-            account: DeepCallable<CountQuery[keyof CountQuery], Account | null>;
-            /* Count multiple account records */
-            accounts: DeepCallable<CountQuery[keyof CountQuery], Accounts>;
-            /* Count a single post record */
-            post: DeepCallable<CountQuery[keyof CountQuery], Post | null>;
-            /* Count multiple post records */
-            posts: DeepCallable<CountQuery[keyof CountQuery], Posts>;
-        };
-        get: {
-            /* Get a single account record */
-            account: DeepCallable<GetQuery[keyof GetQuery], Account | null>;
-            /* Get multiple account records */
-            accounts: DeepCallable<GetQuery[keyof GetQuery], Accounts>;
-            /* Get a single post record */
-            post: DeepCallable<GetQuery[keyof GetQuery], Post | null>;
-            /* Get multiple post records */
-            posts: DeepCallable<GetQuery[keyof GetQuery], Posts>;
-        };
-        remove: {
-            /* Remove a single account record */
-            account: DeepCallable<RemoveQuery[keyof RemoveQuery], Account | null>;
-            /* Remove multiple account records */
-            accounts: DeepCallable<RemoveQuery[keyof RemoveQuery], Accounts>;
-            /* Remove a single post record */
-            post: DeepCallable<RemoveQuery[keyof RemoveQuery], Post | null>;
-            /* Remove multiple post records */
-            posts: DeepCallable<RemoveQuery[keyof RemoveQuery], Posts>;
-        };
-        set: {
-            /* Set a single account record */
-            account: DeepCallable<SetQuery[keyof SetQuery], Account | null>;
-            /* Set multiple account records */
-            accounts: DeepCallable<SetQuery[keyof SetQuery], Accounts>;
-            /* Set a single post record */
-            post: DeepCallable<SetQuery[keyof SetQuery], Post | null>;
-            /* Set multiple post records */
-            posts: DeepCallable<SetQuery[keyof SetQuery], Posts>;
-        };
+        add: typeof add;
+        count: typeof count;
+        get: typeof get;
+        remove: typeof remove;
+        set: typeof set;
     };
     export default function (options: QueryHandlerOptions | (() => QueryHandlerOptions)): {
-        add: {
-            /* Add a single account record */
-            account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
-            /* Add a single post record */
-            post: DeepCallable<AddQuery[keyof AddQuery], Post | null>;
-        };
-        count: {
-            /* Count a single account record */
-            account: DeepCallable<CountQuery[keyof CountQuery], Account | null>;
-            /* Count multiple account records */
-            accounts: DeepCallable<CountQuery[keyof CountQuery], Accounts>;
-            /* Count a single post record */
-            post: DeepCallable<CountQuery[keyof CountQuery], Post | null>;
-            /* Count multiple post records */
-            posts: DeepCallable<CountQuery[keyof CountQuery], Posts>;
-        };
-        get: {
-            /* Get a single account record */
-            account: DeepCallable<GetQuery[keyof GetQuery], Account | null>;
-            /* Get multiple account records */
-            accounts: DeepCallable<GetQuery[keyof GetQuery], Accounts>;
-            /* Get a single post record */
-            post: DeepCallable<GetQuery[keyof GetQuery], Post | null>;
-            /* Get multiple post records */
-            posts: DeepCallable<GetQuery[keyof GetQuery], Posts>;
-        };
-        remove: {
-            /* Remove a single account record */
-            account: DeepCallable<RemoveQuery[keyof RemoveQuery], Account | null>;
-            /* Remove multiple account records */
-            accounts: DeepCallable<RemoveQuery[keyof RemoveQuery], Accounts>;
-            /* Remove a single post record */
-            post: DeepCallable<RemoveQuery[keyof RemoveQuery], Post | null>;
-            /* Remove multiple post records */
-            posts: DeepCallable<RemoveQuery[keyof RemoveQuery], Posts>;
-        };
-        set: {
-            /* Set a single account record */
-            account: DeepCallable<SetQuery[keyof SetQuery], Account | null>;
-            /* Set multiple account records */
-            accounts: DeepCallable<SetQuery[keyof SetQuery], Accounts>;
-            /* Set a single post record */
-            post: DeepCallable<SetQuery[keyof SetQuery], Post | null>;
-            /* Set multiple post records */
-            posts: DeepCallable<SetQuery[keyof SetQuery], Posts>;
-        };
+        add: typeof add;
+        count: typeof count;
+        get: typeof get;
+        remove: typeof remove;
+        set: typeof set;
     };
 }
 "


### PR DESCRIPTION
This change simplifies the types generated for the `createSyntaxFactory` factory builder by instead inferring the types from the existing top level query functions.