### PR TITLE
Fix `count` query return types

### DIFF
--- a/src/generators/module.ts
+++ b/src/generators/module.ts
@@ -85,14 +85,18 @@ export const generateModule = (
           ),
         ]),
       );
-      declarationProperties.push(
-        addSyntheticLeadingComment(
-          singularProperty,
-          SyntaxKind.MultiLineCommentTrivia,
-          comment.singular,
-          true,
-        ),
-      );
+
+      // There is no value in supporting `count` queries for singular
+      // records, so we skip adding the comment for those.
+      if (queryType !== 'count')
+        declarationProperties.push(
+          addSyntheticLeadingComment(
+            singularProperty,
+            SyntaxKind.MultiLineCommentTrivia,
+            comment.singular,
+            true,
+          ),
+        );
 
       // TODO(@nurodev): Remove once RONIN officially supports
       // creating multiple records at once.

--- a/src/generators/module.ts
+++ b/src/generators/module.ts
@@ -75,10 +75,14 @@ export const generateModule = (
         undefined,
         factory.createTypeReferenceNode(identifiers.syntax.deepCallable, [
           queryTypeValue,
-          factory.createUnionTypeNode([
-            singularModelIdentifier,
-            factory.createLiteralTypeNode(factory.createNull()),
-          ]),
+          factory.createUnionTypeNode(
+            queryType === 'count'
+              ? [factory.createKeywordTypeNode(SyntaxKind.NumberKeyword)]
+              : [
+                  singularModelIdentifier,
+                  factory.createLiteralTypeNode(factory.createNull()),
+                ],
+          ),
         ]),
       );
       declarationProperties.push(
@@ -105,7 +109,9 @@ export const generateModule = (
         undefined,
         factory.createTypeReferenceNode(identifiers.syntax.deepCallable, [
           queryTypeValue,
-          pluralSchemaIdentifier,
+          queryType === 'count'
+            ? factory.createKeywordTypeNode(SyntaxKind.NumberKeyword)
+            : pluralSchemaIdentifier,
         ]),
       );
       declarationProperties.push(

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -19,10 +19,8 @@ declare module "ronin" {
         account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
     };
     declare const count: {
-        /* Count a single account record */
-        account: DeepCallable<CountQuery[keyof CountQuery], Account | null>;
         /* Count multiple account records */
-        accounts: DeepCallable<CountQuery[keyof CountQuery], Accounts>;
+        accounts: DeepCallable<CountQuery[keyof CountQuery], number>;
     };
     declare const get: {
         /* Get a single account record */

--- a/tests/generators/__snapshots__/module.test.ts.snap
+++ b/tests/generators/__snapshots__/module.test.ts.snap
@@ -15,10 +15,8 @@ exports[`module a basic model 1`] = `
         account: DeepCallable<AddQuery[keyof AddQuery], Account | null>;
     };
     declare const count: {
-        /* Count a single account record */
-        account: DeepCallable<CountQuery[keyof CountQuery], Account | null>;
         /* Count multiple account records */
-        accounts: DeepCallable<CountQuery[keyof CountQuery], Accounts>;
+        accounts: DeepCallable<CountQuery[keyof CountQuery], number>;
     };
     declare const get: {
         /* Get a single account record */
@@ -106,14 +104,10 @@ exports[`module with multiple models 1`] = `
         post: DeepCallable<AddQuery[keyof AddQuery], Post | null>;
     };
     declare const count: {
-        /* Count a single account record */
-        account: DeepCallable<CountQuery[keyof CountQuery], Account | null>;
         /* Count multiple account records */
-        accounts: DeepCallable<CountQuery[keyof CountQuery], Accounts>;
-        /* Count a single post record */
-        post: DeepCallable<CountQuery[keyof CountQuery], Post | null>;
+        accounts: DeepCallable<CountQuery[keyof CountQuery], number>;
         /* Count multiple post records */
-        posts: DeepCallable<CountQuery[keyof CountQuery], Posts>;
+        posts: DeepCallable<CountQuery[keyof CountQuery], number>;
     };
     declare const get: {
         /* Get a single account record */


### PR DESCRIPTION
This change makes a few minor fixes to the query type generation. Namely to both fix the return type so `count.foo()` returns a `number` instead of the schema, and also removes types for singular schemas. EG: `count.post` types will no longer be generated, but `count.posts` will.