### PR TITLE
Remove `any` types

### DIFF
--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -131,7 +131,7 @@ export const resolveSchemaType = factory.createTypeAliasDeclaration(
       factory.createConditionalTypeNode(
         factory.createTypeReferenceNode(genericIdentifiers.schema),
         factory.createTypeReferenceNode(identifiers.primitive.array, [
-          factory.createKeywordTypeNode(SyntaxKind.AnyKeyword),
+          factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword),
         ]),
         factory.createTypeReferenceNode(identifiers.primitive.array, [
           factory.createKeywordTypeNode(SyntaxKind.StringKeyword),

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -4,7 +4,7 @@ exports[`generate a basic model 1`] = `
 "import type { AddQuery, CountQuery, GetQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
 import type { DeepCallable, ResultRecord } from "@ronin/syntax/queries";
 import type { QueryHandlerOptions } from "ronin/types";
-type ResolveSchema<TSchema, TUsing extends Array<string> | "all", TKey extends string> = TUsing extends "all" ? TSchema : TKey extends TUsing[number] ? TSchema : TSchema extends Array<any> ? Array<string> : string;
+type ResolveSchema<TSchema, TUsing extends Array<string> | "all", TKey extends string> = TUsing extends "all" ? TSchema : TKey extends TUsing[number] ? TSchema : TSchema extends Array<unknown> ? Array<string> : string;
 declare module "ronin" {
     export type Account = ResultRecord & {
         email: string;
@@ -64,7 +64,7 @@ exports[`generate with no models 1`] = `
 "import type { AddQuery, CountQuery, GetQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
 import type { DeepCallable, ResultRecord } from "@ronin/syntax/queries";
 import type { QueryHandlerOptions } from "ronin/types";
-type ResolveSchema<TSchema, TUsing extends Array<string> | "all", TKey extends string> = TUsing extends "all" ? TSchema : TKey extends TUsing[number] ? TSchema : TSchema extends Array<any> ? Array<string> : string;
+type ResolveSchema<TSchema, TUsing extends Array<string> | "all", TKey extends string> = TUsing extends "all" ? TSchema : TKey extends TUsing[number] ? TSchema : TSchema extends Array<unknown> ? Array<string> : string;
 declare module "ronin" {
     declare const add: {};
     declare const count: {};


### PR DESCRIPTION
This changes removes the one and only instance of `any` in the generated code.
I have checked the code locally & confirmed that the types act exactly the same but switching to `unknown` means it's less likely user linting tools will flag an issue.