### PR TITLE
Added support for `get.models()` types

### DIFF
--- a/src/generators/module.ts
+++ b/src/generators/module.ts
@@ -238,17 +238,24 @@ export const generateModule = (
    *  get: typeof get,
    *  remove: typeof remove,
    *  set: typeof set,
+   *  alter: typeof alter,
+   *  batch: typeof batch,
+   *  create: typeof create,
+   *  drop: typeof drop,
+   *  sql: typeof sql,
+   *  sqlBatch: typeof sqlBatch,
    * }
    * ```
    */
   const csfReturnTypeDec = factory.createTypeLiteralNode(
-    QUERY_TYPE_NAMES.map((queryType) =>
-      factory.createPropertySignature(
-        undefined,
-        factory.createIdentifier(queryType),
-        undefined,
-        factory.createTypeQueryNode(factory.createIdentifier(queryType)),
-      ),
+    [...QUERY_TYPE_NAMES, 'alter', 'batch', 'create', 'drop', 'sql', 'sqlBatch'].map(
+      (queryType) =>
+        factory.createPropertySignature(
+          undefined,
+          factory.createIdentifier(queryType),
+          undefined,
+          factory.createTypeQueryNode(factory.createIdentifier(queryType)),
+        ),
     ),
   );
 

--- a/src/generators/module.ts
+++ b/src/generators/module.ts
@@ -54,7 +54,6 @@ export const generateModule = (
        */
       const queryTypeValue = factory.createIndexedAccessTypeNode(
         factory.createTypeReferenceNode(
-          // identifiers.compiler.queryType[queryType],
           identifiers.compiler.queryType[queryType],
           undefined,
         ),
@@ -123,6 +122,54 @@ export const generateModule = (
           pluralProperty,
           SyntaxKind.MultiLineCommentTrivia,
           comment.plural,
+          true,
+        ),
+      );
+    }
+
+    // Make sure to always add `get.models()` to the `get` query type
+    // declaration, even if there are no models defined.
+    if (queryType === 'get') {
+      const model = {
+        pluralSlug: 'models',
+      } as Model;
+
+      /**
+       * ```ts
+       * GetQuery[keyof GetQuery]
+       * ```
+       */
+      const queryTypeValue = factory.createIndexedAccessTypeNode(
+        factory.createTypeReferenceNode(
+          identifiers.compiler.queryType[queryType],
+          undefined,
+        ),
+        factory.createTypeOperatorNode(
+          SyntaxKind.KeyOfKeyword,
+          factory.createTypeReferenceNode(identifiers.compiler.queryType[queryType]),
+        ),
+      );
+
+      /**
+       * ```ts
+       * models: DeepCallable<GetQuery[keyof GetQuery], Array<Models>>;
+       * ```
+       */
+      const property = factory.createPropertySignature(
+        undefined,
+        model.pluralSlug,
+        undefined,
+        factory.createTypeReferenceNode(identifiers.syntax.deepCallable, [
+          queryTypeValue,
+          factory.createTypeReferenceNode(convertToPascalCase(model.pluralSlug)),
+        ]),
+      );
+
+      declarationProperties.push(
+        addSyntheticLeadingComment(
+          property,
+          SyntaxKind.MultiLineCommentTrivia,
+          ' Get all current models ',
           true,
         ),
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export const generate = (models: Array<Model>): string => {
     importQueryHandlerOptionsType,
   );
 
-  // Some types or imports are only needed if certain field types are provided
+  // Some types or imports are only needed if certain field types are provided.
   for (const model of models) {
     const hasStoredObjectFields = Object.values(model.fields).some(
       (field) => field.type === 'blob',

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,18 +30,25 @@ export const generate = (models: Array<Model>): string => {
     importRoninQueryTypesType,
     importSyntaxUtiltypesType,
     importQueryHandlerOptionsType,
-    resolveSchemaType,
-    jsonArrayType,
-    jsonObjectType,
-    jsonPrimitiveType,
   );
 
-  // If there is any models that have a `blob()` field, we need to import the
-  // `StoredObject` type from the `@ronin/compiler` package.
-  const hasStoredObjectField = models.some((model) =>
-    Object.values(model.fields).some((field) => field.type === 'blob'),
-  );
-  if (hasStoredObjectField) nodes.push(importRoninStoredObjectType);
+  // Some types or imports are only needed if certain field types are provided
+  for (const model of models) {
+    const hasStoredObjectFields = Object.values(model.fields).some(
+      (field) => field.type === 'blob',
+    );
+    if (hasStoredObjectFields) nodes.push(importRoninStoredObjectType);
+
+    const hasLinkFields = Object.values(model.fields).some(
+      (field) => field.type === 'link',
+    );
+    if (hasLinkFields) nodes.push(resolveSchemaType);
+
+    const hasJsonFields = Object.values(model.fields).some(
+      (field) => field.type === 'json',
+    );
+    if (hasJsonFields) nodes.push(jsonArrayType, jsonObjectType, jsonPrimitiveType);
+  }
 
   // Generate and add the type declarations for each model.
   const typeDeclarations = generateTypes(models);

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -47,6 +47,12 @@ declare module "ronin" {
         get: typeof get;
         remove: typeof remove;
         set: typeof set;
+        alter: typeof alter;
+        batch: typeof batch;
+        create: typeof create;
+        drop: typeof drop;
+        sql: typeof sql;
+        sqlBatch: typeof sqlBatch;
     };
     export default function (options: QueryHandlerOptions | (() => QueryHandlerOptions)): {
         add: typeof add;
@@ -54,6 +60,12 @@ declare module "ronin" {
         get: typeof get;
         remove: typeof remove;
         set: typeof set;
+        alter: typeof alter;
+        batch: typeof batch;
+        create: typeof create;
+        drop: typeof drop;
+        sql: typeof sql;
+        sqlBatch: typeof sqlBatch;
     };
 }
 "
@@ -78,6 +90,12 @@ declare module "ronin" {
         get: typeof get;
         remove: typeof remove;
         set: typeof set;
+        alter: typeof alter;
+        batch: typeof batch;
+        create: typeof create;
+        drop: typeof drop;
+        sql: typeof sql;
+        sqlBatch: typeof sqlBatch;
     };
     export default function (options: QueryHandlerOptions | (() => QueryHandlerOptions)): {
         add: typeof add;
@@ -85,6 +103,12 @@ declare module "ronin" {
         get: typeof get;
         remove: typeof remove;
         set: typeof set;
+        alter: typeof alter;
+        batch: typeof batch;
+        create: typeof create;
+        drop: typeof drop;
+        sql: typeof sql;
+        sqlBatch: typeof sqlBatch;
     };
 }
 "

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -4,12 +4,6 @@ exports[`generate a basic model 1`] = `
 "import type { AddQuery, CountQuery, GetQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
 import type { DeepCallable, ResultRecord } from "@ronin/syntax/queries";
 import type { QueryHandlerOptions } from "ronin/types";
-type ResolveSchema<TSchema, TUsing extends Array<string> | "all", TKey extends string> = TUsing extends "all" ? TSchema : TKey extends TUsing[number] ? TSchema : TSchema extends Array<unknown> ? Array<string> : string;
-type JsonArray = Array<JsonPrimitive | JsonObject | JsonArray>;
-type JsonObject = {
-    [key: string]: JsonPrimitive | JsonObject | JsonArray;
-};
-type JsonPrimitive = string | number | boolean | null;
 declare module "ronin" {
     export type Account = ResultRecord & {
         email: string;
@@ -32,6 +26,8 @@ declare module "ronin" {
         account: DeepCallable<GetQuery[keyof GetQuery], Account | null>;
         /* Get multiple account records */
         accounts: DeepCallable<GetQuery[keyof GetQuery], Accounts>;
+        /* Get all current models */
+        models: DeepCallable<GetQuery[keyof GetQuery], Models>;
     };
     declare const remove: {
         /* Remove a single account record */
@@ -67,16 +63,13 @@ exports[`generate with no models 1`] = `
 "import type { AddQuery, CountQuery, GetQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
 import type { DeepCallable, ResultRecord } from "@ronin/syntax/queries";
 import type { QueryHandlerOptions } from "ronin/types";
-type ResolveSchema<TSchema, TUsing extends Array<string> | "all", TKey extends string> = TUsing extends "all" ? TSchema : TKey extends TUsing[number] ? TSchema : TSchema extends Array<unknown> ? Array<string> : string;
-type JsonArray = Array<JsonPrimitive | JsonObject | JsonArray>;
-type JsonObject = {
-    [key: string]: JsonPrimitive | JsonObject | JsonArray;
-};
-type JsonPrimitive = string | number | boolean | null;
 declare module "ronin" {
     declare const add: {};
     declare const count: {};
-    declare const get: {};
+    declare const get: {
+        /* Get all current models */
+        models: DeepCallable<GetQuery[keyof GetQuery], Models>;
+    };
     declare const remove: {};
     declare const set: {};
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {

--- a/tests/generators/__snapshots__/module.test.ts.snap
+++ b/tests/generators/__snapshots__/module.test.ts.snap
@@ -44,6 +44,12 @@ exports[`module a basic model 1`] = `
         get: typeof get;
         remove: typeof remove;
         set: typeof set;
+        alter: typeof alter;
+        batch: typeof batch;
+        create: typeof create;
+        drop: typeof drop;
+        sql: typeof sql;
+        sqlBatch: typeof sqlBatch;
     };
     export default function (options: QueryHandlerOptions | (() => QueryHandlerOptions)): {
         add: typeof add;
@@ -51,6 +57,12 @@ exports[`module a basic model 1`] = `
         get: typeof get;
         remove: typeof remove;
         set: typeof set;
+        alter: typeof alter;
+        batch: typeof batch;
+        create: typeof create;
+        drop: typeof drop;
+        sql: typeof sql;
+        sqlBatch: typeof sqlBatch;
     };
 }
 "
@@ -72,6 +84,12 @@ exports[`module with no modules 1`] = `
         get: typeof get;
         remove: typeof remove;
         set: typeof set;
+        alter: typeof alter;
+        batch: typeof batch;
+        create: typeof create;
+        drop: typeof drop;
+        sql: typeof sql;
+        sqlBatch: typeof sqlBatch;
     };
     export default function (options: QueryHandlerOptions | (() => QueryHandlerOptions)): {
         add: typeof add;
@@ -79,6 +97,12 @@ exports[`module with no modules 1`] = `
         get: typeof get;
         remove: typeof remove;
         set: typeof set;
+        alter: typeof alter;
+        batch: typeof batch;
+        create: typeof create;
+        drop: typeof drop;
+        sql: typeof sql;
+        sqlBatch: typeof sqlBatch;
     };
 }
 "
@@ -152,6 +176,12 @@ exports[`module with multiple models 1`] = `
         get: typeof get;
         remove: typeof remove;
         set: typeof set;
+        alter: typeof alter;
+        batch: typeof batch;
+        create: typeof create;
+        drop: typeof drop;
+        sql: typeof sql;
+        sqlBatch: typeof sqlBatch;
     };
     export default function (options: QueryHandlerOptions | (() => QueryHandlerOptions)): {
         add: typeof add;
@@ -159,6 +189,12 @@ exports[`module with multiple models 1`] = `
         get: typeof get;
         remove: typeof remove;
         set: typeof set;
+        alter: typeof alter;
+        batch: typeof batch;
+        create: typeof create;
+        drop: typeof drop;
+        sql: typeof sql;
+        sqlBatch: typeof sqlBatch;
     };
 }
 "

--- a/tests/generators/__snapshots__/module.test.ts.snap
+++ b/tests/generators/__snapshots__/module.test.ts.snap
@@ -23,6 +23,8 @@ exports[`module a basic model 1`] = `
         account: DeepCallable<GetQuery[keyof GetQuery], Account | null>;
         /* Get multiple account records */
         accounts: DeepCallable<GetQuery[keyof GetQuery], Accounts>;
+        /* Get all current models */
+        models: DeepCallable<GetQuery[keyof GetQuery], Models>;
     };
     declare const remove: {
         /* Remove a single account record */
@@ -58,7 +60,10 @@ exports[`module with no modules 1`] = `
 "declare module "ronin" {
     declare const add: {};
     declare const count: {};
-    declare const get: {};
+    declare const get: {
+        /* Get all current models */
+        models: DeepCallable<GetQuery[keyof GetQuery], Models>;
+    };
     declare const remove: {};
     declare const set: {};
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
@@ -118,6 +123,8 @@ exports[`module with multiple models 1`] = `
         post: DeepCallable<GetQuery[keyof GetQuery], Post | null>;
         /* Get multiple post records */
         posts: DeepCallable<GetQuery[keyof GetQuery], Posts>;
+        /* Get all current models */
+        models: DeepCallable<GetQuery[keyof GetQuery], Models>;
     };
     declare const remove: {
         /* Remove a single account record */


### PR DESCRIPTION
This change both adds the types to the module augmentation to for `get.models()` queries, along with fixing a bug with the `createSyntaxFactory` where some exports from it, including `alter`, `create`, `drop`, etc.