### PR TITLE
Replace `get.models()` types with `list.models()`

### DIFF
--- a/src/constants/identifiers.ts
+++ b/src/constants/identifiers.ts
@@ -21,6 +21,7 @@ export const identifiers = {
       remove: factory.createIdentifier('RemoveQuery'),
       set: factory.createIdentifier('SetQuery'),
     },
+    model: factory.createIdentifier('Model'),
     module: {
       root: factory.createIdentifier(JSON.stringify('@ronin/compiler')),
     },

--- a/src/constants/identifiers.ts
+++ b/src/constants/identifiers.ts
@@ -11,7 +11,10 @@ import type { Identifier } from 'typescript';
  */
 export const identifiers = {
   compiler: {
-    queryType: {
+    ddlQueryType: {
+      list: factory.createIdentifier('ListQuery'),
+    },
+    dmlQueryType: {
       add: factory.createIdentifier('AddQuery'),
       count: factory.createIdentifier('CountQuery'),
       get: factory.createIdentifier('GetQuery'),

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -10,11 +10,12 @@ import { createImportDeclaration } from '@/src/generators/import';
  */
 export const importRoninQueryTypesType = createImportDeclaration({
   identifiers: [
-    { name: identifiers.compiler.queryType.add },
-    { name: identifiers.compiler.queryType.count },
-    { name: identifiers.compiler.queryType.get },
-    { name: identifiers.compiler.queryType.remove },
-    { name: identifiers.compiler.queryType.set },
+    { name: identifiers.compiler.dmlQueryType.add },
+    { name: identifiers.compiler.dmlQueryType.count },
+    { name: identifiers.compiler.dmlQueryType.get },
+    { name: identifiers.compiler.ddlQueryType.list },
+    { name: identifiers.compiler.dmlQueryType.remove },
+    { name: identifiers.compiler.dmlQueryType.set },
   ],
   module: identifiers.compiler.module.root,
   type: true,

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -5,7 +5,7 @@ import { createImportDeclaration } from '@/src/generators/import';
 
 /**
  * ```ts
- * import type { AddQuery, CountQuery, GetQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
+ * import type { AddQuery, CountQuery, GetQuery, ListQuery, Model, RemoveQuery, SetQuery } from "@ronin/compiler";
  * ```
  */
 export const importRoninQueryTypesType = createImportDeclaration({
@@ -14,6 +14,7 @@ export const importRoninQueryTypesType = createImportDeclaration({
     { name: identifiers.compiler.dmlQueryType.count },
     { name: identifiers.compiler.dmlQueryType.get },
     { name: identifiers.compiler.ddlQueryType.list },
+    { name: identifiers.compiler.model },
     { name: identifiers.compiler.dmlQueryType.remove },
     { name: identifiers.compiler.dmlQueryType.set },
   ],

--- a/src/generators/module.ts
+++ b/src/generators/module.ts
@@ -1,3 +1,4 @@
+import { DDL_QUERY_TYPES, DML_QUERY_TYPES } from '@ronin/compiler';
 import { NodeFlags, SyntaxKind, addSyntheticLeadingComment, factory } from 'typescript';
 
 import { identifiers } from '@/src/constants/identifiers';
@@ -13,7 +14,6 @@ import type {
 } from 'typescript';
 
 import type { Model } from '@/src/types/model';
-import { DDL_QUERY_TYPES, DML_QUERY_TYPES } from '@ronin/compiler';
 
 /**
  * Generate a module augmentation for the `ronin` module to override the
@@ -54,12 +54,12 @@ export const generateModule = (
        */
       const queryTypeValue = factory.createIndexedAccessTypeNode(
         factory.createTypeReferenceNode(
-          identifiers.compiler.queryType[queryType],
+          identifiers.compiler.dmlQueryType[queryType],
           undefined,
         ),
         factory.createTypeOperatorNode(
           SyntaxKind.KeyOfKeyword,
-          factory.createTypeReferenceNode(identifiers.compiler.queryType[queryType]),
+          factory.createTypeReferenceNode(identifiers.compiler.dmlQueryType[queryType]),
         ),
       );
 
@@ -127,54 +127,6 @@ export const generateModule = (
       );
     }
 
-    // Make sure to always add `get.models()` to the `get` query type
-    // declaration, even if there are no models defined.
-    if (queryType === 'get') {
-      const model = {
-        pluralSlug: 'models',
-      } as Model;
-
-      /**
-       * ```ts
-       * GetQuery[keyof GetQuery]
-       * ```
-       */
-      const queryTypeValue = factory.createIndexedAccessTypeNode(
-        factory.createTypeReferenceNode(
-          identifiers.compiler.queryType[queryType],
-          undefined,
-        ),
-        factory.createTypeOperatorNode(
-          SyntaxKind.KeyOfKeyword,
-          factory.createTypeReferenceNode(identifiers.compiler.queryType[queryType]),
-        ),
-      );
-
-      /**
-       * ```ts
-       * models: DeepCallable<GetQuery[keyof GetQuery], Array<Models>>;
-       * ```
-       */
-      const property = factory.createPropertySignature(
-        undefined,
-        model.pluralSlug,
-        undefined,
-        factory.createTypeReferenceNode(identifiers.syntax.deepCallable, [
-          queryTypeValue,
-          factory.createTypeReferenceNode(convertToPascalCase(model.pluralSlug)),
-        ]),
-      );
-
-      declarationProperties.push(
-        addSyntheticLeadingComment(
-          property,
-          SyntaxKind.MultiLineCommentTrivia,
-          ' Get all current models ',
-          true,
-        ),
-      );
-    }
-
     return {
       properties: declarationProperties,
       queryType,
@@ -207,6 +159,56 @@ export const generateModule = (
 
     moduleBodyStatements.push(queryDeclaration);
   }
+
+  /**
+   * ```ts
+   * models: DeepCallable<ListQuery[keyof ListQuery], Array<Models>>;
+   * ```
+   */
+  const listModelsQueryPropertyDeclaration = addSyntheticLeadingComment(
+    factory.createPropertySignature(
+      undefined,
+      'models',
+      undefined,
+      factory.createTypeReferenceNode(identifiers.syntax.deepCallable, [
+        factory.createIndexedAccessTypeNode(
+          factory.createTypeReferenceNode(
+            identifiers.compiler.ddlQueryType.list,
+            undefined,
+          ),
+          factory.createTypeOperatorNode(
+            SyntaxKind.KeyOfKeyword,
+            factory.createTypeReferenceNode(identifiers.compiler.ddlQueryType.list),
+          ),
+        ),
+        factory.createTypeReferenceNode('Models'),
+      ]),
+    ),
+    SyntaxKind.MultiLineCommentTrivia,
+    ' List all model definitions ',
+    true,
+  );
+
+  /**
+   * ```ts
+   * declare const add: { ... };
+   * ```
+   */
+  const listModelsQueryDeclaration = factory.createVariableStatement(
+    [factory.createModifier(SyntaxKind.DeclareKeyword)],
+    factory.createVariableDeclarationList(
+      [
+        factory.createVariableDeclaration(
+          'list',
+          undefined,
+          factory.createTypeLiteralNode([listModelsQueryPropertyDeclaration]),
+        ),
+      ],
+      NodeFlags.Const,
+    ),
+  );
+
+  moduleBodyStatements.push(listModelsQueryDeclaration);
 
   // Note: `csf` prefix stands for `createSyntaxFactory`.
 

--- a/src/generators/module.ts
+++ b/src/generators/module.ts
@@ -162,7 +162,7 @@ export const generateModule = (
 
   /**
    * ```ts
-   * models: DeepCallable<ListQuery[keyof ListQuery], Array<Models>>;
+   * models: DeepCallable<ListQuery[keyof ListQuery], Array<Model>>;
    * ```
    */
   const listModelsQueryPropertyDeclaration = addSyntheticLeadingComment(
@@ -181,7 +181,9 @@ export const generateModule = (
             factory.createTypeReferenceNode(identifiers.compiler.ddlQueryType.list),
           ),
         ),
-        factory.createTypeReferenceNode('Models'),
+        factory.createTypeReferenceNode(identifiers.primitive.array, [
+          factory.createTypeReferenceNode(identifiers.compiler.model),
+        ]),
       ]),
     ),
     SyntaxKind.MultiLineCommentTrivia,

--- a/src/generators/module.ts
+++ b/src/generators/module.ts
@@ -193,7 +193,7 @@ export const generateModule = (
 
   /**
    * ```ts
-   * declare const add: { ... };
+   * declare const list: { ... };
    * ```
    */
   const listModelsQueryDeclaration = factory.createVariableStatement(

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generate a basic model 1`] = `
-"import type { AddQuery, CountQuery, GetQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
+"import type { AddQuery, CountQuery, GetQuery, ListQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
 import type { DeepCallable, ResultRecord } from "@ronin/syntax/queries";
 import type { QueryHandlerOptions } from "ronin/types";
 declare module "ronin" {
@@ -18,8 +18,6 @@ declare module "ronin" {
         account: DeepCallable<GetQuery[keyof GetQuery], Account | null>;
         /* Get multiple account records */
         accounts: DeepCallable<GetQuery[keyof GetQuery], Accounts>;
-        /* Get all current models */
-        models: DeepCallable<GetQuery[keyof GetQuery], Models>;
     };
     declare const count: {
         /* Count multiple account records */
@@ -40,6 +38,10 @@ declare module "ronin" {
         account: DeepCallable<RemoveQuery[keyof RemoveQuery], Account | null>;
         /* Remove multiple account records */
         accounts: DeepCallable<RemoveQuery[keyof RemoveQuery], Accounts>;
+    };
+    declare const list: {
+        /* List all model definitions */
+        models: DeepCallable<ListQuery[keyof ListQuery], Models>;
     };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
         get: typeof get;
@@ -74,18 +76,19 @@ declare module "ronin" {
 `;
 
 exports[`generate with no models 1`] = `
-"import type { AddQuery, CountQuery, GetQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
+"import type { AddQuery, CountQuery, GetQuery, ListQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
 import type { DeepCallable, ResultRecord } from "@ronin/syntax/queries";
 import type { QueryHandlerOptions } from "ronin/types";
 declare module "ronin" {
-    declare const get: {
-        /* Get all current models */
-        models: DeepCallable<GetQuery[keyof GetQuery], Models>;
-    };
+    declare const get: {};
     declare const count: {};
     declare const set: {};
     declare const add: {};
     declare const remove: {};
+    declare const list: {
+        /* List all model definitions */
+        models: DeepCallable<ListQuery[keyof ListQuery], Models>;
+    };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
         get: typeof get;
         count: typeof count;

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generate a basic model 1`] = `
-"import type { AddQuery, CountQuery, GetQuery, ListQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
+"import type { AddQuery, CountQuery, GetQuery, ListQuery, Model, RemoveQuery, SetQuery } from "@ronin/compiler";
 import type { DeepCallable, ResultRecord } from "@ronin/syntax/queries";
 import type { QueryHandlerOptions } from "ronin/types";
 declare module "ronin" {
@@ -41,7 +41,7 @@ declare module "ronin" {
     };
     declare const list: {
         /* List all model definitions */
-        models: DeepCallable<ListQuery[keyof ListQuery], Models>;
+        models: DeepCallable<ListQuery[keyof ListQuery], Array<Model>>;
     };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
         get: typeof get;
@@ -76,7 +76,7 @@ declare module "ronin" {
 `;
 
 exports[`generate with no models 1`] = `
-"import type { AddQuery, CountQuery, GetQuery, ListQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
+"import type { AddQuery, CountQuery, GetQuery, ListQuery, Model, RemoveQuery, SetQuery } from "@ronin/compiler";
 import type { DeepCallable, ResultRecord } from "@ronin/syntax/queries";
 import type { QueryHandlerOptions } from "ronin/types";
 declare module "ronin" {
@@ -87,7 +87,7 @@ declare module "ronin" {
     declare const remove: {};
     declare const list: {
         /* List all model definitions */
-        models: DeepCallable<ListQuery[keyof ListQuery], Models>;
+        models: DeepCallable<ListQuery[keyof ListQuery], Array<Model>>;
     };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
         get: typeof get;

--- a/tests/constants/__snapshots__/identifiers.test.ts.snap
+++ b/tests/constants/__snapshots__/identifiers.test.ts.snap
@@ -3,11 +3,11 @@
 exports[`identifiers 1`] = `
 {
   "compiler": {
-    "module": {
-      "root": IdentifierObject {
+    "ddlQueryType": {
+      "list": IdentifierObject {
         "emitNode": undefined,
         "end": -1,
-        "escapedText": ""@ronin/compiler"",
+        "escapedText": "ListQuery",
         "flags": 16,
         "flowNode": undefined,
         "id": 0,
@@ -19,7 +19,7 @@ exports[`identifiers 1`] = `
         "transformFlags": 0,
       },
     },
-    "queryType": {
+    "dmlQueryType": {
       "add": IdentifierObject {
         "emitNode": undefined,
         "end": -1,
@@ -80,6 +80,22 @@ exports[`identifiers 1`] = `
         "emitNode": undefined,
         "end": -1,
         "escapedText": "SetQuery",
+        "flags": 16,
+        "flowNode": undefined,
+        "id": 0,
+        "jsDoc": undefined,
+        "kind": 80,
+        "parent": undefined,
+        "pos": -1,
+        "symbol": undefined,
+        "transformFlags": 0,
+      },
+    },
+    "module": {
+      "root": IdentifierObject {
+        "emitNode": undefined,
+        "end": -1,
+        "escapedText": ""@ronin/compiler"",
         "flags": 16,
         "flowNode": undefined,
         "id": 0,

--- a/tests/constants/__snapshots__/identifiers.test.ts.snap
+++ b/tests/constants/__snapshots__/identifiers.test.ts.snap
@@ -91,6 +91,20 @@ exports[`identifiers 1`] = `
         "transformFlags": 0,
       },
     },
+    "model": IdentifierObject {
+      "emitNode": undefined,
+      "end": -1,
+      "escapedText": "Model",
+      "flags": 16,
+      "flowNode": undefined,
+      "id": 0,
+      "jsDoc": undefined,
+      "kind": 80,
+      "parent": undefined,
+      "pos": -1,
+      "symbol": undefined,
+      "transformFlags": 0,
+    },
     "module": {
       "root": IdentifierObject {
         "emitNode": undefined,

--- a/tests/declarations.test.ts
+++ b/tests/declarations.test.ts
@@ -11,7 +11,7 @@ describe('declarations', () => {
   test('import the RONIN namespace type from `ronin`', () => {
     const output = printNodes([importRoninQueryTypesType]);
     expect(output).toStrictEqual(
-      `import type { AddQuery, CountQuery, GetQuery, RemoveQuery, SetQuery } from \"@ronin/compiler\";\n`,
+      `import type { AddQuery, CountQuery, GetQuery, ListQuery, RemoveQuery, SetQuery } from \"@ronin/compiler\";\n`,
     );
   });
 

--- a/tests/declarations.test.ts
+++ b/tests/declarations.test.ts
@@ -11,7 +11,7 @@ describe('declarations', () => {
   test('import the RONIN namespace type from `ronin`', () => {
     const output = printNodes([importRoninQueryTypesType]);
     expect(output).toStrictEqual(
-      `import type { AddQuery, CountQuery, GetQuery, ListQuery, RemoveQuery, SetQuery } from \"@ronin/compiler\";\n`,
+      `import type { AddQuery, CountQuery, GetQuery, ListQuery, Model, RemoveQuery, SetQuery } from \"@ronin/compiler\";\n`,
     );
   });
 

--- a/tests/generators/__snapshots__/module.test.ts.snap
+++ b/tests/generators/__snapshots__/module.test.ts.snap
@@ -15,8 +15,6 @@ exports[`module a basic model 1`] = `
         account: DeepCallable<GetQuery[keyof GetQuery], Account | null>;
         /* Get multiple account records */
         accounts: DeepCallable<GetQuery[keyof GetQuery], Accounts>;
-        /* Get all current models */
-        models: DeepCallable<GetQuery[keyof GetQuery], Models>;
     };
     declare const count: {
         /* Count multiple account records */
@@ -37,6 +35,10 @@ exports[`module a basic model 1`] = `
         account: DeepCallable<RemoveQuery[keyof RemoveQuery], Account | null>;
         /* Remove multiple account records */
         accounts: DeepCallable<RemoveQuery[keyof RemoveQuery], Accounts>;
+    };
+    declare const list: {
+        /* List all model definitions */
+        models: DeepCallable<ListQuery[keyof ListQuery], Models>;
     };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
         get: typeof get;
@@ -72,14 +74,15 @@ exports[`module a basic model 1`] = `
 
 exports[`module with no modules 1`] = `
 "declare module "ronin" {
-    declare const get: {
-        /* Get all current models */
-        models: DeepCallable<GetQuery[keyof GetQuery], Models>;
-    };
+    declare const get: {};
     declare const count: {};
     declare const set: {};
     declare const add: {};
     declare const remove: {};
+    declare const list: {
+        /* List all model definitions */
+        models: DeepCallable<ListQuery[keyof ListQuery], Models>;
+    };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
         get: typeof get;
         count: typeof count;
@@ -139,8 +142,6 @@ exports[`module with multiple models 1`] = `
         post: DeepCallable<GetQuery[keyof GetQuery], Post | null>;
         /* Get multiple post records */
         posts: DeepCallable<GetQuery[keyof GetQuery], Posts>;
-        /* Get all current models */
-        models: DeepCallable<GetQuery[keyof GetQuery], Models>;
     };
     declare const count: {
         /* Count multiple account records */
@@ -173,6 +174,10 @@ exports[`module with multiple models 1`] = `
         post: DeepCallable<RemoveQuery[keyof RemoveQuery], Post | null>;
         /* Remove multiple post records */
         posts: DeepCallable<RemoveQuery[keyof RemoveQuery], Posts>;
+    };
+    declare const list: {
+        /* List all model definitions */
+        models: DeepCallable<ListQuery[keyof ListQuery], Models>;
     };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
         get: typeof get;

--- a/tests/generators/__snapshots__/module.test.ts.snap
+++ b/tests/generators/__snapshots__/module.test.ts.snap
@@ -38,7 +38,7 @@ exports[`module a basic model 1`] = `
     };
     declare const list: {
         /* List all model definitions */
-        models: DeepCallable<ListQuery[keyof ListQuery], Models>;
+        models: DeepCallable<ListQuery[keyof ListQuery], Array<Model>>;
     };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
         get: typeof get;
@@ -81,7 +81,7 @@ exports[`module with no modules 1`] = `
     declare const remove: {};
     declare const list: {
         /* List all model definitions */
-        models: DeepCallable<ListQuery[keyof ListQuery], Models>;
+        models: DeepCallable<ListQuery[keyof ListQuery], Array<Model>>;
     };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
         get: typeof get;
@@ -177,7 +177,7 @@ exports[`module with multiple models 1`] = `
     };
     declare const list: {
         /* List all model definitions */
-        models: DeepCallable<ListQuery[keyof ListQuery], Models>;
+        models: DeepCallable<ListQuery[keyof ListQuery], Array<Model>>;
     };
     declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
         get: typeof get;


### PR DESCRIPTION
This change removes the `get.models()` type definitions in favour of ones for `list.models()`.

In addition to this it also applies some minor type fixes, such as importing the missing `Model` type.