### PR TITLE
Generate Zod schemas

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import type { Node } from 'typescript';
 
 import type { Model } from '@/src/types/model';
 import { convertToPascalCase } from '@/src/utils/slug';
+import type { ModelField } from '@ronin/compiler';
 
 /**
  * Generates the complete `index.d.ts` file for a list of RONIN models.
@@ -62,6 +63,18 @@ export const generate = (models: Array<Model>): string => {
   return printNodes(nodes);
 };
 
+type ModelFieldType = Required<ModelField>['type'];
+
+const ZOD_FIELD_TYPES: Record<ModelFieldType, string> = {
+  string: 'string',
+  number: 'number',
+  boolean: 'boolean',
+  date: 'date',
+  json: 'any',
+  link: 'any',
+  blob: 'any',
+};
+
 /**
  * Generates the complete `index.ts` Zod schema file for a list of RONIN models.
  *
@@ -79,7 +92,15 @@ export const generateZodSchema = (models: Array<Model>): string => {
     lines.push(`export const ${modelName} = z.object({`);
 
     for (const [fieldSlug, field] of Object.entries(model.fields)) {
-      lines.push(`  ${fieldSlug}: z.${field.type}(),`);
+      const fieldType = field.type as ModelFieldType;
+      const zodType = ZOD_FIELD_TYPES[fieldType];
+      if (!zodType) continue;
+
+      const methods = [zodType];
+      if (field.required) methods.push('required');
+      const stringMethods = methods.map(method => `${method}()`).join('.');
+
+      lines.push(`  ${fieldSlug}: z.${stringMethods},`);
     }
 
     lines.push('});\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ export const generateZodSchema = (models: Array<Model>): string => {
 
       const methods = [zodType];
       if (field.required) methods.push('required');
-      const stringMethods = methods.map(method => `${method}()`).join('.');
+      const stringMethods = methods.map((method) => `${method}()`).join('.');
 
       lines.push(`  ${fieldSlug}: z.${stringMethods},`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import type { Node } from 'typescript';
 import type { Model } from '@/src/types/model';
 
 /**
- * Generates the complete `index.d.ts` file for a RONIN package.
+ * Generates the complete `index.d.ts` file for a list of RONIN models.
  *
  * @param models - A list of models to generate the the types for.
  *
@@ -59,4 +59,28 @@ export const generate = (models: Array<Model>): string => {
   nodes.push(moduleAugmentation);
 
   return printNodes(nodes);
+};
+
+/**
+ * Generates the complete `index.ts` Zod schema file for a list of RONIN models.
+ *
+ * @param models - A list of models to generate the the types for.
+ *
+ * @returns A string of the complete `index.ts` file.
+ */
+export const generateZodSchema = (models: Array<Model>): string => {
+  const lines = new Array<string | null>();
+  lines.push('import zod as z from "zod";\n');
+
+  for (const model of models) {
+    lines.push(`export const ${model.name} = z.object({`);
+
+    for (const [fieldSlug, field] of Object.entries(model.fields)) {
+      lines.push(`${fieldSlug}: z.${field.type}(),`);
+    }
+
+    lines.push('});\n');
+  }
+
+  return lines.join('\n');
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { printNodes } from '@/src/utils/print';
 import type { Node } from 'typescript';
 
 import type { Model } from '@/src/types/model';
+import { convertToPascalCase } from '@/src/utils/slug';
 
 /**
  * Generates the complete `index.d.ts` file for a list of RONIN models.
@@ -73,10 +74,12 @@ export const generateZodSchema = (models: Array<Model>): string => {
   lines.push('import zod as z from "zod";\n');
 
   for (const model of models) {
-    lines.push(`export const ${model.name} = z.object({`);
+    const modelName = convertToPascalCase(model.slug);
+
+    lines.push(`export const ${modelName} = z.object({`);
 
     for (const [fieldSlug, field] of Object.entries(model.fields)) {
-      lines.push(`${fieldSlug}: z.${field.type}(),`);
+      lines.push(`  ${fieldSlug}: z.${field.type}(),`);
     }
 
     lines.push('});\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export const generate = (models: Array<Model>): string => {
  */
 export const generateZodSchema = (models: Array<Model>): string => {
   const lines = new Array<string | null>();
-  lines.push('import zod as z from "zod";\n');
+  lines.push('import { z } from "zod";\n');
 
   for (const model of models) {
     const modelName = convertToPascalCase(model.slug);

--- a/tests/__snapshots__/zod.test.ts.snap
+++ b/tests/__snapshots__/zod.test.ts.snap
@@ -3,9 +3,9 @@
 exports[`generate a basic model 1`] = `
 "import zod as z from "zod";
 
-export const undefined = z.object({
-name: z.string(),
-email: z.string(),
+export const Account = z.object({
+  name: z.string(),
+  email: z.string(),
 });
 "
 `;
@@ -13,10 +13,10 @@ email: z.string(),
 exports[`generate a basic model with blob field 1`] = `
 "import zod as z from "zod";
 
-export const undefined = z.object({
-name: z.string(),
-email: z.string(),
-image: z.blob(),
+export const Account = z.object({
+  name: z.string(),
+  email: z.string(),
+  image: z.blob(),
 });
 "
 `;

--- a/tests/__snapshots__/zod.test.ts.snap
+++ b/tests/__snapshots__/zod.test.ts.snap
@@ -1,0 +1,27 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generate a basic model 1`] = `
+"import zod as z from "zod";
+
+export const undefined = z.object({
+name: z.string(),
+email: z.string(),
+});
+"
+`;
+
+exports[`generate a basic model with blob field 1`] = `
+"import zod as z from "zod";
+
+export const undefined = z.object({
+name: z.string(),
+email: z.string(),
+image: z.blob(),
+});
+"
+`;
+
+exports[`generate with no models 1`] = `
+"import zod as z from "zod";
+"
+`;

--- a/tests/__snapshots__/zod.test.ts.snap
+++ b/tests/__snapshots__/zod.test.ts.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generate a basic model 1`] = `
-"import zod as z from "zod";
+"import { z } from "zod";
 
 export const Account = z.object({
   name: z.string(),
@@ -11,7 +11,7 @@ export const Account = z.object({
 `;
 
 exports[`generate a basic model with blob field 1`] = `
-"import zod as z from "zod";
+"import { z } from "zod";
 
 export const Account = z.object({
   name: z.string(),
@@ -22,6 +22,6 @@ export const Account = z.object({
 `;
 
 exports[`generate with no models 1`] = `
-"import zod as z from "zod";
+"import { z } from "zod";
 "
 `;

--- a/tests/__snapshots__/zod.test.ts.snap
+++ b/tests/__snapshots__/zod.test.ts.snap
@@ -4,8 +4,8 @@ exports[`generate a basic model 1`] = `
 "import { z } from "zod";
 
 export const Account = z.object({
-  name: z.string(),
-  email: z.string(),
+  name: z.string().required(),
+  email: z.string().required(),
 });
 "
 `;
@@ -14,9 +14,9 @@ exports[`generate a basic model with blob field 1`] = `
 "import { z } from "zod";
 
 export const Account = z.object({
-  name: z.string(),
-  email: z.string(),
-  image: z.blob(),
+  name: z.string().required(),
+  email: z.string().required(),
+  image: z.any().required(),
 });
 "
 `;

--- a/tests/zod.test.ts
+++ b/tests/zod.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { blob, model, string } from '@ronin/syntax/schema';
+
+import { generateZodSchema } from '@/src/index';
+
+describe('generate', () => {
+  test('a basic model', () => {
+    const AccountModel = model({
+      slug: 'account',
+      pluralSlug: 'accounts',
+      fields: {
+        name: string(),
+        email: string({ required: true }),
+      },
+    });
+
+    // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.
+    // @ts-expect-error Codegen models types differ from the schema model types.
+    const output = generateZodSchema([AccountModel]);
+    expect(output).toMatchSnapshot();
+  });
+
+  test('a basic model with blob field', () => {
+    const AccountModel = model({
+      slug: 'account',
+      pluralSlug: 'accounts',
+      fields: {
+        name: string(),
+        email: string({ required: true }),
+        image: blob(),
+      },
+    });
+
+    // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.
+    // @ts-expect-error Codegen models types differ from the schema model types.
+    const output = generateZodSchema([AccountModel]);
+    expect(output).toMatchSnapshot();
+  });
+
+  test('with no models', () => {
+    const output = generateZodSchema([]);
+    expect(output).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
This change exposes a function named `generateZodSchema` from the package, which, as the name suggests, allows for generating a [Zod](https://zod.dev) schema from RONIN model definitions.