### PR TITLE
Remove `optional()` chain from fields with a default value

### DIFF
--- a/src/zod.ts
+++ b/src/zod.ts
@@ -78,7 +78,8 @@ export const generateZodSchema = (models: Array<Model>): string => {
       if (fieldSlug === 'email' && field.type === 'string')
         chainedSchemaMethods.push('email()');
 
-      if (field.required !== true) chainedSchemaMethods.push('optional()');
+      if (field.required !== true && !('defaultValue' in field))
+        chainedSchemaMethods.push('optional()');
 
       const normalizedFieldSlug = fieldSlug.includes('.')
         ? JSON.stringify(fieldSlug)

--- a/tests/__snapshots__/zod.test.ts.snap
+++ b/tests/__snapshots__/zod.test.ts.snap
@@ -72,6 +72,17 @@ export const AccountSchema = z.object({
 "
 `;
 
+exports[`generate with a default value 1`] = `
+"import { z } from "zod";
+
+export const AccountSchema = z.object({
+	name: z.string().optional(),
+	email: z.string().email(),
+	role: z.string(),
+});
+"
+`;
+
 exports[`generate with no models 1`] = `
 "import { z } from "zod";
 

--- a/tests/zod.test.ts
+++ b/tests/zod.test.ts
@@ -94,6 +94,23 @@ describe('generate', () => {
     expect(output).toMatchSnapshot();
   });
 
+  test('with a default value', () => {
+    const AccountModel = model({
+      slug: 'account',
+      pluralSlug: 'accounts',
+      fields: {
+        name: string(),
+        email: string({ required: true }),
+        role: string({ defaultValue: 'user' }),
+      },
+    });
+
+    // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.
+    // @ts-expect-error Codegen models types differ from the schema model types.
+    const output = generateZodSchema([AccountModel]);
+    expect(output).toMatchSnapshot();
+  });
+
   test('with no models', () => {
     const output = generateZodSchema([]);
     expect(output).toMatchSnapshot();


### PR DESCRIPTION
This change updates the Zod generator to only add the `.optional()` chain to a field if both it is marked as required and doesn't include a `defaultValue` field.