### PR TITLE
Add nested field support to Zod schemas

### DIFF
--- a/tests/__snapshots__/zod.test.ts.snap
+++ b/tests/__snapshots__/zod.test.ts.snap
@@ -39,7 +39,9 @@ exports[`generate with dot notation keys 1`] = `
 "import { z } from "zod";
 
 export const AccountSchema = z.object({
-	"foo.bar": z.string().optional(),
+	foo: z.object({
+		bar: z.string().optional(),
+	});
 });
 "
 `;
@@ -79,6 +81,19 @@ export const AccountSchema = z.object({
 	name: z.string().optional(),
 	email: z.string().email(),
 	role: z.string(),
+});
+"
+`;
+
+exports[`generate with a nested field 1`] = `
+"import { z } from "zod";
+
+export const AccountSchema = z.object({
+	name: z.string().optional(),
+	nested: z.object({
+		foo: z.string(),
+		bar: z.number().optional(),
+	});
 });
 "
 `;

--- a/tests/zod.test.ts
+++ b/tests/zod.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { blob, json, model, string } from '@ronin/syntax/schema';
+import { blob, json, model, number, string } from '@ronin/syntax/schema';
 
 import { generateZodSchema } from '@/src/zod';
 
@@ -102,6 +102,23 @@ describe('generate', () => {
         name: string(),
         email: string({ required: true }),
         role: string({ defaultValue: 'user' }),
+      },
+    });
+
+    // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.
+    // @ts-expect-error Codegen models types differ from the schema model types.
+    const output = generateZodSchema([AccountModel]);
+    expect(output).toMatchSnapshot();
+  });
+
+  test('with a nested field', () => {
+    const AccountModel = model({
+      slug: 'account',
+      pluralSlug: 'accounts',
+      fields: {
+        name: string(),
+        'nested.foo': string({ required: true }),
+        'nested.bar': number(),
       },
     });
 


### PR DESCRIPTION
This change updates the Zod generator to allow for use of nested fields, such as `foo.bar` or `ronin.createdAt`, such that they are structured as Zod object rather than a dot notation key.