### PR TITLE
Add support for nested fields to type generator

### DIFF
--- a/src/generators/types.ts
+++ b/src/generators/types.ts
@@ -122,9 +122,13 @@ export const generateTypes = (
         if (field.required === false && field.type === 'link' && field.kind !== 'many')
           propertyUnionTypes.push(factory.createLiteralTypeNode(factory.createNull()));
 
+        const normalizedSlug = field.slug.includes('.')
+          ? JSON.stringify(field.slug)
+          : field.slug;
+
         return factory.createPropertySignature(
           undefined,
-          field.slug,
+          normalizedSlug,
           undefined,
           factory.createUnionTypeNode(propertyUnionTypes),
         );

--- a/tests/generators/__snapshots__/types.test.ts.snap
+++ b/tests/generators/__snapshots__/types.test.ts.snap
@@ -102,3 +102,21 @@ export type Accounts = Array<Account> & {
 };
 "
 `;
+
+exports[`types a model with nested fields 1`] = `
+"/**
+ * A user account.
+ */
+export type Account = ResultRecord & {
+    "nested.bar": number;
+    "nested.foo": string;
+};
+/**
+ * A user account.
+ */
+export type Accounts = Array<Account> & {
+    moreBefore?: string;
+    moreAfter?: string;
+};
+"
+`;

--- a/tests/generators/types.test.ts
+++ b/tests/generators/types.test.ts
@@ -169,4 +169,27 @@ describe('types', () => {
 
     expect(typesResultStr).toMatchSnapshot();
   });
+
+  test('a model with nested fields', () => {
+    const AccountModel = model({
+      slug: 'account',
+      pluralSlug: 'accounts',
+      fields: {
+        'nested.foo': string(),
+        'nested.bar': number(),
+      },
+      // @ts-expect-error This property is not native to RONIN models.
+      summary: 'A user account.',
+    });
+
+    // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.
+    // @ts-expect-error Codegen models types differ from the schema model types.
+    const typesResult = generateTypes([AccountModel], AccountModel);
+
+    expect(typesResult).toHaveLength(2);
+
+    const typesResultStr = printNodes(typesResult);
+
+    expect(typesResultStr).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
This change updates the types generator to correctly serialize object keys when using nested fields. The example below better shows the fix.

### Before
```ts
/**
 * A user account.
 */
export type Account = ResultRecord & {
    nested.bar: number;
    nested.foo: string;
};
```

### After
```ts
/**
 * A user account.
 */
export type Account = ResultRecord & {
    "nested.bar": number;
    "nested.foo": string;
};
```