### PR TITLE
Fix invalid Zod schema syntax

### DIFF
--- a/src/zod.ts
+++ b/src/zod.ts
@@ -103,7 +103,7 @@ export const generateZodSchema = (models: Array<Model>): string => {
           const zodObjectBody = Array.from(value.entries())
             .map(([nestedKey, nestedValue]) => `\t\t${nestedKey}: ${nestedValue},`)
             .join('\n');
-          return `\t${key}: z.object({\n${zodObjectBody}\n\t});`;
+          return `\t${key}: z.object({\n${zodObjectBody}\n\t}),`;
         })
         .join('\n')}\n});`,
     );

--- a/tests/__snapshots__/zod.test.ts.snap
+++ b/tests/__snapshots__/zod.test.ts.snap
@@ -41,7 +41,7 @@ exports[`generate with dot notation keys 1`] = `
 export const AccountSchema = z.object({
 	foo: z.object({
 		bar: z.string().optional(),
-	});
+	}),
 });
 "
 `;
@@ -93,7 +93,7 @@ export const AccountSchema = z.object({
 	nested: z.object({
 		foo: z.string(),
 		bar: z.number().optional(),
-	});
+	}),
 });
 "
 `;


### PR DESCRIPTION
This change fixes a bug with the Zod schema generator whereby the output of nested fields would end with a `;`, which breaks the syntax  of the completed schema.