### PR TITLE
Add `.readonly()` to `id` fields in Zod schemas

### DIFF
--- a/src/zod.ts
+++ b/src/zod.ts
@@ -81,6 +81,9 @@ export const generateZodSchema = (models: Array<Model>): string => {
       if (field.required !== true && !('defaultValue' in field))
         chainedSchemaMethods.push('optional()');
 
+      if (fieldSlug === 'id' && field.type === 'string')
+        chainedSchemaMethods.push('readonly()');
+
       if (!fieldSlug.includes('.')) {
         entries.set(fieldSlug, chainedSchemaMethods.join('.'));
         continue;

--- a/tests/__snapshots__/zod.test.ts.snap
+++ b/tests/__snapshots__/zod.test.ts.snap
@@ -104,3 +104,13 @@ exports[`generate with no models 1`] = `
 export {};
 "
 `;
+
+exports[`generate with \`id\` field being read-only 1`] = `
+"import { z } from "zod";
+
+export const AccountSchema = z.object({
+	id: z.string().optional().readonly(),
+	name: z.string().optional(),
+});
+"
+`;

--- a/tests/zod.test.ts
+++ b/tests/zod.test.ts
@@ -128,6 +128,23 @@ describe('generate', () => {
     expect(output).toMatchSnapshot();
   });
 
+  test('with `id` field being read-only', () => {
+    const AccountModel = model({
+      slug: 'account',
+      pluralSlug: 'accounts',
+      fields: {
+        // @ts-expect-error `id` is a reserved field.
+        id: string(),
+        name: string(),
+      },
+    });
+
+    // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.
+    // @ts-expect-error Codegen models types differ from the schema model types.
+    const output = generateZodSchema([AccountModel]);
+    expect(output).toMatchSnapshot();
+  });
+
   test('with no models', () => {
     const output = generateZodSchema([]);
     expect(output).toMatchSnapshot();


### PR DESCRIPTION
This change updates the Zod generator to add `.readonly()` to the schema property chain if the property name is `id`.