### PR TITLE
Map nested fields to a nested type object

### DIFF
--- a/src/generators/types.ts
+++ b/src/generators/types.ts
@@ -6,13 +6,13 @@ import { convertToPascalCase } from '@/src/utils/slug';
 
 import type {
   InterfaceDeclaration,
-  PropertySignature,
   TypeAliasDeclaration,
   TypeNode,
   TypeParameterDeclaration,
 } from 'typescript';
 
 import type { Model, ModelField } from '@/src/types/model';
+import { mapRoninFieldToTypeNode } from '@/src/utils/types';
 
 const DEFAULT_FIELD_SLUGS = [
   'id',
@@ -114,84 +114,14 @@ export const generateTypes = (
         factory.createTypeLiteralNode(
           fields
             .sort((a, b) => a.slug.localeCompare(b.slug))
-            .map((field) => {
-              const propertyUnionTypes = new Array<TypeNode>();
-
-              switch (field.type) {
-                case 'link': {
-                  // Check to make sure the target model exists. If it doesn't we
-                  // fall back to using `unknown` as the type.
-                  const targetModel = models.find((model) => model.slug === field.target);
-                  if (!targetModel) {
-                    propertyUnionTypes.push(
-                      factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword),
-                    );
-                    break;
-                  }
-
-                  // If the field is marked as `many` then we need to wrap the
-                  // type in an array.
-                  const schemaTypeRef = factory.createTypeReferenceNode(
-                    convertToPascalCase(targetModel.slug),
-                  );
-                  const resolvedLinkFieldNode = factory.createTypeReferenceNode(
-                    identifiers.utils.resolveSchema,
-                    [
-                      field.kind === 'many'
-                        ? factory.createTypeReferenceNode(identifiers.primitive.array, [
-                            schemaTypeRef,
-                          ])
-                        : schemaTypeRef,
-
-                      factory.createTypeReferenceNode(genericIdentifiers.using),
-
-                      factory.createLiteralTypeNode(
-                        factory.createStringLiteral(field.slug),
-                      ),
-                    ],
-                  );
-
-                  propertyUnionTypes.push(resolvedLinkFieldNode);
-                  break;
-                }
-                case 'blob':
-                case 'boolean':
-                case 'date':
-                case 'json':
-                case 'number':
-                case 'string': {
-                  const primitive = MODEL_TYPE_TO_SYNTAX_KIND_KEYWORD[field.type];
-                  propertyUnionTypes.push(primitive);
-                  break;
-                }
-                default: {
-                  propertyUnionTypes.push(
-                    factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword),
-                  );
-                  break;
-                }
-              }
-
-              // We need to mark fields as nullable if they are:
-              // - Not required
-              // - Not a link field
-              // - Not a many-to-many link field
-              if (
-                field.required === false &&
-                field.type === 'link' &&
-                field.kind !== 'many'
-              )
-                propertyUnionTypes.push(
-                  factory.createLiteralTypeNode(factory.createNull()),
-                );
-
-              return factory.createPropertySignature(
+            .map((field) =>
+              factory.createPropertySignature(
                 undefined,
                 field.slug,
                 undefined,
-                factory.createUnionTypeNode(propertyUnionTypes),
-              );
-            })
+                factory.createUnionTypeNode(mapRoninFieldToTypeNode(field, models)),
+              ),
+            )
             .filter(Boolean),
         ),
       ]),

--- a/src/generators/types.ts
+++ b/src/generators/types.ts
@@ -57,79 +57,6 @@ export const generateTypes = (
       (field) =>
         field.type === 'link' && models.some((model) => model.slug === field.target),
     );
-    const mappedModelFields = fields
-      .sort((a, b) => a.slug.localeCompare(b.slug))
-      .map((field) => {
-        const propertyUnionTypes = new Array<TypeNode>();
-
-        switch (field.type) {
-          case 'link': {
-            // Check to make sure the target model exists. If it doesn't we
-            // fall back to using `unknown` as the type.
-            const targetModel = models.find((model) => model.slug === field.target);
-            if (!targetModel) {
-              propertyUnionTypes.push(
-                factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword),
-              );
-              break;
-            }
-
-            // If the field is marked as `many` then we need to wrap the
-            // type in an array.
-            const schemaTypeRef = factory.createTypeReferenceNode(
-              convertToPascalCase(targetModel.slug),
-            );
-            const resolvedLinkFieldNode = factory.createTypeReferenceNode(
-              identifiers.utils.resolveSchema,
-              [
-                field.kind === 'many'
-                  ? factory.createTypeReferenceNode(identifiers.primitive.array, [
-                      schemaTypeRef,
-                    ])
-                  : schemaTypeRef,
-
-                factory.createTypeReferenceNode(genericIdentifiers.using),
-
-                factory.createLiteralTypeNode(factory.createStringLiteral(field.slug)),
-              ],
-            );
-
-            propertyUnionTypes.push(resolvedLinkFieldNode);
-            break;
-          }
-          case 'blob':
-          case 'boolean':
-          case 'date':
-          case 'json':
-          case 'number':
-          case 'string': {
-            const primitive = MODEL_TYPE_TO_SYNTAX_KIND_KEYWORD[field.type];
-            propertyUnionTypes.push(primitive);
-            break;
-          }
-          default: {
-            propertyUnionTypes.push(
-              factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword),
-            );
-            break;
-          }
-        }
-
-        // We need to mark fields as nullable if they are:
-        // - Not required
-        // - Not a link field
-        // - Not a many-to-many link field
-        if (field.required === false && field.type === 'link' && field.kind !== 'many')
-          propertyUnionTypes.push(factory.createLiteralTypeNode(factory.createNull()));
-
-        return factory.createPropertySignature(
-          undefined,
-          field.slug,
-          undefined,
-          factory.createUnionTypeNode(propertyUnionTypes),
-        );
-      })
-      .filter(Boolean) as Array<PropertySignature>;
 
     const modelInterfaceTypeParameters = new Array<TypeParameterDeclaration>();
     const linkFieldKeys = fields
@@ -184,7 +111,89 @@ export const generateTypes = (
           identifiers.syntax.resultRecord,
           undefined,
         ),
-        factory.createTypeLiteralNode(mappedModelFields),
+        factory.createTypeLiteralNode(
+          fields
+            .sort((a, b) => a.slug.localeCompare(b.slug))
+            .map((field) => {
+              const propertyUnionTypes = new Array<TypeNode>();
+
+              switch (field.type) {
+                case 'link': {
+                  // Check to make sure the target model exists. If it doesn't we
+                  // fall back to using `unknown` as the type.
+                  const targetModel = models.find((model) => model.slug === field.target);
+                  if (!targetModel) {
+                    propertyUnionTypes.push(
+                      factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword),
+                    );
+                    break;
+                  }
+
+                  // If the field is marked as `many` then we need to wrap the
+                  // type in an array.
+                  const schemaTypeRef = factory.createTypeReferenceNode(
+                    convertToPascalCase(targetModel.slug),
+                  );
+                  const resolvedLinkFieldNode = factory.createTypeReferenceNode(
+                    identifiers.utils.resolveSchema,
+                    [
+                      field.kind === 'many'
+                        ? factory.createTypeReferenceNode(identifiers.primitive.array, [
+                            schemaTypeRef,
+                          ])
+                        : schemaTypeRef,
+
+                      factory.createTypeReferenceNode(genericIdentifiers.using),
+
+                      factory.createLiteralTypeNode(
+                        factory.createStringLiteral(field.slug),
+                      ),
+                    ],
+                  );
+
+                  propertyUnionTypes.push(resolvedLinkFieldNode);
+                  break;
+                }
+                case 'blob':
+                case 'boolean':
+                case 'date':
+                case 'json':
+                case 'number':
+                case 'string': {
+                  const primitive = MODEL_TYPE_TO_SYNTAX_KIND_KEYWORD[field.type];
+                  propertyUnionTypes.push(primitive);
+                  break;
+                }
+                default: {
+                  propertyUnionTypes.push(
+                    factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword),
+                  );
+                  break;
+                }
+              }
+
+              // We need to mark fields as nullable if they are:
+              // - Not required
+              // - Not a link field
+              // - Not a many-to-many link field
+              if (
+                field.required === false &&
+                field.type === 'link' &&
+                field.kind !== 'many'
+              )
+                propertyUnionTypes.push(
+                  factory.createLiteralTypeNode(factory.createNull()),
+                );
+
+              return factory.createPropertySignature(
+                undefined,
+                field.slug,
+                undefined,
+                factory.createUnionTypeNode(propertyUnionTypes),
+              );
+            })
+            .filter(Boolean),
+        ),
       ]),
     );
 

--- a/src/generators/types.ts
+++ b/src/generators/types.ts
@@ -122,13 +122,9 @@ export const generateTypes = (
         if (field.required === false && field.type === 'link' && field.kind !== 'many')
           propertyUnionTypes.push(factory.createLiteralTypeNode(factory.createNull()));
 
-        const normalizedSlug = field.slug.includes('.')
-          ? JSON.stringify(field.slug)
-          : field.slug;
-
         return factory.createPropertySignature(
           undefined,
-          normalizedSlug,
+          field.slug,
           undefined,
           factory.createUnionTypeNode(propertyUnionTypes),
         );

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -116,17 +116,9 @@ export const remapNestedFields = (
       continue;
     }
 
-    if (Array.isArray(parentField)) {
-      parentField.push(nestedField);
-      continue;
-    }
+    if (!Array.isArray(parentField)) continue;
 
-    if (parentField) {
-      remappedFields.set(parentSlug, [parentField, field]);
-      continue;
-    }
-
-    remappedFields.set(parentSlug, [nestedField]);
+    parentField.push(nestedField);
   }
 
   return Array.from(remappedFields.entries());

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,83 @@
+import { SyntaxKind, factory } from 'typescript';
+
+import { genericIdentifiers, identifiers } from '@/src/constants/identifiers';
+import { MODEL_TYPE_TO_SYNTAX_KIND_KEYWORD } from '@/src/constants/schema';
+import { convertToPascalCase } from '@/src/utils/slug';
+
+import type { ModelField } from '@ronin/compiler';
+import type { TypeNode } from 'typescript';
+
+import type { Model } from '@/src/types/model';
+
+/**
+ * Map a RONIN model field to a TypeScript type node.
+ *
+ * @param field - The RONIN model field to map.
+ * @param models - The list of all RONIN models. Used to resolve link fields.
+ *
+ * @returns An array of TypeScript type nodes representing the field type.
+ */
+export const mapRoninFieldToTypeNode = (
+  field: ModelField,
+  models: Array<Model>,
+): Array<TypeNode> => {
+  const propertyUnionTypes = new Array<TypeNode>();
+
+  switch (field.type) {
+    case 'link': {
+      // Check to make sure the target model exists. If it doesn't we
+      // fall back to using `unknown` as the type.
+      const targetModel = models.find((model) => model.slug === field.target);
+      if (!targetModel) {
+        propertyUnionTypes.push(factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword));
+        break;
+      }
+
+      // If the field is marked as `many` then we need to wrap the
+      // type in an array.
+      const schemaTypeRef = factory.createTypeReferenceNode(
+        convertToPascalCase(targetModel.slug),
+      );
+      const resolvedLinkFieldNode = factory.createTypeReferenceNode(
+        identifiers.utils.resolveSchema,
+        [
+          field.kind === 'many'
+            ? factory.createTypeReferenceNode(identifiers.primitive.array, [
+                schemaTypeRef,
+              ])
+            : schemaTypeRef,
+
+          factory.createTypeReferenceNode(genericIdentifiers.using),
+
+          factory.createLiteralTypeNode(factory.createStringLiteral(field.slug)),
+        ],
+      );
+
+      propertyUnionTypes.push(resolvedLinkFieldNode);
+      break;
+    }
+    case 'blob':
+    case 'boolean':
+    case 'date':
+    case 'json':
+    case 'number':
+    case 'string': {
+      const primitive = MODEL_TYPE_TO_SYNTAX_KIND_KEYWORD[field.type];
+      propertyUnionTypes.push(primitive);
+      break;
+    }
+    default: {
+      propertyUnionTypes.push(factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword));
+      break;
+    }
+  }
+
+  // We need to mark fields as nullable if they are:
+  // - Not required
+  // - Not a link field
+  // - Not a many-to-many link field
+  if (field.required === false && field.type === 'link' && field.kind !== 'many')
+    propertyUnionTypes.push(factory.createLiteralTypeNode(factory.createNull()));
+
+  return propertyUnionTypes;
+};

--- a/tests/generators/__snapshots__/types.test.ts.snap
+++ b/tests/generators/__snapshots__/types.test.ts.snap
@@ -108,6 +108,7 @@ exports[`types a model with nested fields 1`] = `
  * A user account.
  */
 export type Account = ResultRecord & {
+    name: string;
     nested: {
         bar: number;
         foo: string;

--- a/tests/generators/__snapshots__/types.test.ts.snap
+++ b/tests/generators/__snapshots__/types.test.ts.snap
@@ -108,8 +108,10 @@ exports[`types a model with nested fields 1`] = `
  * A user account.
  */
 export type Account = ResultRecord & {
-    "nested.bar": number;
-    "nested.foo": string;
+    nested: {
+        bar: number;
+        foo: string;
+    };
 };
 /**
  * A user account.

--- a/tests/generators/types.test.ts
+++ b/tests/generators/types.test.ts
@@ -175,6 +175,7 @@ describe('types', () => {
       slug: 'account',
       pluralSlug: 'accounts',
       fields: {
+        name: string(),
         'nested.foo': string(),
         'nested.bar': number(),
       },


### PR DESCRIPTION
This change updates the types generator, along with some refactoring, to remap the incoming fields such that any fields, like `nested.foo` & `nested.bar`, to an object like `{ nested: { foo: '...', bar: '...' } }`.

### Before
```ts
export type Account = ResultRecord & {
    name: string;
    "nested.bar": number;
    "nested.foo": string;
};
```
### After
```ts
export type Account = ResultRecord & {
    name: string;
    nested: {
        bar: number;
        foo: string;
    };
};
```